### PR TITLE
force hf to use pytorch and not use tf

### DIFF
--- a/mii/models/load_models.py
+++ b/mii/models/load_models.py
@@ -11,7 +11,10 @@ def hf_provider(model_path, model_name, task_name, mii_config):
     local_rank = int(os.getenv('LOCAL_RANK', '0'))
     os.environ['TRANSFORMERS_CACHE'] = model_path
     from transformers import pipeline
-    inference_pipeline = pipeline(task_name, model=model_name, device=local_rank, framework="pt")
+    inference_pipeline = pipeline(task_name,
+                                  model=model_name,
+                                  device=local_rank,
+                                  framework="pt")
     if mii_config.torch_dtype() == torch.half:
         inference_pipeline.model.half()
     return inference_pipeline


### PR DESCRIPTION
Newer HF will attempt to use TensorFlow if it's installed, we always want to make sure we use PyTorch.