### PR TITLE
various clean-up

### DIFF
--- a/examples/local/conversational-example.py
+++ b/examples/local/conversational-example.py
@@ -3,7 +3,7 @@ import mii
 mii_configs = {'tensor_parallel': 1}
 
 # gpt2
-name = "microsoft/DialoGPT-small"
+name = "microsoft/DialoGPT-large"
 
 print(f"Deploying {name}...")
 

--- a/examples/local/conversational-query-example.py
+++ b/examples/local/conversational-query-example.py
@@ -1,7 +1,7 @@
 import mii
 
 # gpt2
-name = "microsoft/DialoGPT-small"
+name = "microsoft/DialoGPT-medium"
 
 print(f"Querying {name}...")
 
@@ -18,13 +18,13 @@ result = generator.query({
 print(result)
 print(f"time_taken: {result.time_taken}")
 
-str = "How is DeepSpeed?"
-result = generator.query({
-    'text': str,
-    'conversation_id': result.conversation_id,
-    'past_user_inputs': result.past_user_inputs,
-    'generated_responses': result.generated_responses
-})
+# str = "How is DeepSpeed?"
+# result = generator.query({
+#     'text': str,
+#     'conversation_id': result.conversation_id,
+#     'past_user_inputs': result.past_user_inputs,
+#     'generated_responses': result.generated_responses
+# })
 
-print(result)
-print("time_taken:", result.time_taken)
+# print(result)
+# print("time_taken:", result.time_taken)

--- a/examples/local/fill-mask-example.py
+++ b/examples/local/fill-mask-example.py
@@ -2,8 +2,7 @@ import mii
 
 # roberta
 name = "roberta-base"
-
-name = "bert-base-uncased"
+name = "bert-base-cased"
 
 print(f"Deploying {name}...")
 

--- a/examples/local/fill-mask-query-example.py
+++ b/examples/local/fill-mask-query-example.py
@@ -2,13 +2,16 @@ import mii
 
 # roberta
 name = "roberta-base"
+name = "roberta-large"
 mask = "<mask>"
 # bert
-name = "bert-base-uncased"
+name = "bert-base-cased"
 mask = "[MASK]"
 print(f"Querying {name}...")
 
 generator = mii.mii_query_handle(name + "_deployment")
+
 result = generator.query({'query': "Hello I'm a " + mask + " model."})
 print(result.response)
 print("time_taken:", result.time_taken)
+print("model_time_taken:", result.model_time_taken)

--- a/examples/local/question-answering-query-example.py
+++ b/examples/local/question-answering-query-example.py
@@ -2,7 +2,7 @@ import mii
 
 name = "deepset/roberta-large-squad2"
 
-generator = mii.mii_query_handle(name + "-qa-deployment")
+generator = mii.mii_query_handle(name + "_deployment")
 results = generator.query({
     'question': "What is the greatest?",
     'context': "DeepSpeed is the greatest"

--- a/mii/config.py
+++ b/mii/config.py
@@ -11,6 +11,8 @@ class MIIConfig(BaseModel):
     checkpoint_dict: Union[dict, None] = None
     deploy_rank: Union[int, List[int]] = -1
     torch_dist_port: int = 29500
+    replace_with_kernel_inject: bool = True
+    profile_model_time: bool = False
 
     @validator('dtype')
     def dtype_valid(cls, value):
@@ -54,9 +56,9 @@ class MIIConfig(BaseModel):
     @staticmethod
     def _torch_dtype(value):
         value = value.lower()
-        if value == "float" or value == "fp32":
+        if value == "float" or value == "fp32" or value == "float32":
             dtype = torch.float
-        elif value == "half" or value == "fp16":
+        elif value == "half" or value == "fp16" or value == "float16":
             dtype = torch.half
         elif value == "int8":
             dtype = torch.int8

--- a/mii/constants.py
+++ b/mii/constants.py
@@ -49,6 +49,7 @@ SUPPORTED_MODEL_TYPES = {
     'bert': ModelProvider.HUGGING_FACE,
     'gpt_neo': ModelProvider.HUGGING_FACE,
     'gptj': ModelProvider.HUGGING_FACE,
+    'opt': ModelProvider.HUGGING_FACE,
     'gpt-neox': ModelProvider.ELEUTHER_AI,
     'bloom': ModelProvider.HUGGING_FACE_LLM,
 }

--- a/mii/grpc_related/modelresponse_server.py
+++ b/mii/grpc_related/modelresponse_server.py
@@ -26,13 +26,30 @@ class ModelResponse(modelresponse_pb2_grpc.ModelResponseServicer):
         }
         return query_kwargs
 
+    def _get_model_time(self, model, sum_times=False):
+        model_times = []
+        # Only grab model times if profiling was enabled/exists
+        if getattr(model, "model_profile_enabled", False):
+            model_times = model.model_times()
+
+        if len(model_times) > 0:
+            if sum_times:
+                model_time = sum(model_times)
+            else:
+                # Unclear how to combine values, so just grab the most recent one
+                model_time = model_times[-1]
+        else:
+            # no model times were captured
+            model_time = -1
+        return model_time
+
     def GeneratorReply(self, request, context):
         query_kwargs = self._unpack_proto_query_kwargs(request.query_kwargs)
-        start = time.time()
 
         # unpack grpc list into py-list
         request = [r for r in request.request]
 
+        start = time.time()
         batched_responses = self.inference_pipeline(request, **query_kwargs)
         end = time.time()
 
@@ -42,8 +59,11 @@ class ModelResponse(modelresponse_pb2_grpc.ModelResponseServicer):
             text = response[0]['generated_text']
             text_responses.append(text)
 
+        model_time = self._get_model_time(self.inference_pipeline.model, sum_times=True)
+
         val = modelresponse_pb2.MultiStringReply(response=text_responses,
-                                                 time_taken=end - start)
+                                                 time_taken=end - start,
+                                                 model_time_taken=model_time)
         return val
 
     def ClassificationReply(self, request, context):
@@ -53,8 +73,10 @@ class ModelResponse(modelresponse_pb2_grpc.ModelResponseServicer):
                                            return_all_scores=True,
                                            **query_kwargs)
         end = time.time()
+        model_time = self._get_model_time(self.inference_pipeline.model)
         return modelresponse_pb2.SingleStringReply(response=f"{response}",
-                                                   time_taken=end - start)
+                                                   time_taken=end - start,
+                                                   model_time_taken=model_time)
 
     def QuestionAndAnswerReply(self, request, context):
         query_kwargs = self._unpack_proto_query_kwargs(request.query_kwargs)
@@ -63,24 +85,31 @@ class ModelResponse(modelresponse_pb2_grpc.ModelResponseServicer):
                                            context=request.context,
                                            **query_kwargs)
         end = time.time()
+        model_time = self._get_model_time(self.inference_pipeline.model)
         return modelresponse_pb2.SingleStringReply(response=f"{response}",
-                                                   time_taken=end - start)
+                                                   time_taken=end - start,
+                                                   model_time_taken=model_time)
 
     def FillMaskReply(self, request, context):
         query_kwargs = self._unpack_proto_query_kwargs(request.query_kwargs)
         start = time.time()
         response = self.inference_pipeline(request.request, **query_kwargs)
         end = time.time()
+
+        model_time = self._get_model_time(self.inference_pipeline.model)
         return modelresponse_pb2.SingleStringReply(response=f"{response}",
-                                                   time_taken=end - start)
+                                                   time_taken=end - start,
+                                                   model_time_taken=model_time)
 
     def TokenClassificationReply(self, request, context):
         query_kwargs = self._unpack_proto_query_kwargs(request.query_kwargs)
         start = time.time()
         response = self.inference_pipeline(request.request, **query_kwargs)
         end = time.time()
+        model_time = self._get_model_time(self.inference_pipeline.model)
         return modelresponse_pb2.SingleStringReply(response=f"{response}",
-                                                   time_taken=end - start)
+                                                   time_taken=end - start,
+                                                   model_time_taken=model_time)
 
     def ConversationalReply(self, request, context):
         query_kwargs = self._unpack_proto_query_kwargs(request.query_kwargs)
@@ -92,11 +121,13 @@ class ModelResponse(modelresponse_pb2_grpc.ModelResponseServicer):
                             **query_kwargs)
         self.inference_pipeline(conv)
         end = time.time()
+        model_time = self._get_model_time(self.inference_pipeline.model)
         return modelresponse_pb2.ConversationReply(
             conversation_id=conv.uuid,
             past_user_inputs=conv.past_user_inputs,
             generated_responses=conv.generated_responses,
-            time_taken=end - start)
+            time_taken=end - start,
+            model_time_taken=model_time)
 
 
 def serve(inference_pipeline, port):

--- a/mii/grpc_related/proto/modelresponse.proto
+++ b/mii/grpc_related/proto/modelresponse.proto
@@ -54,11 +54,13 @@ message MultiStringRequest {
 message SingleStringReply {
   string response = 1;
   float time_taken = 2;
+  float model_time_taken = 3;
 }
 
 message MultiStringReply {
   repeated string response = 1;
   float time_taken = 2;
+  float model_time_taken = 3;
 }
 
 message QARequest {
@@ -80,4 +82,5 @@ message ConversationReply {
   repeated string past_user_inputs = 2;
   repeated string generated_responses = 3;
   float time_taken = 4;
+  float model_time_taken = 5;
 }

--- a/mii/grpc_related/proto/modelresponse_pb2.py
+++ b/mii/grpc_related/proto/modelresponse_pb2.py
@@ -11,7 +11,7 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x13modelresponse.proto\x12\rmodelresponse\"_\n\x05Value\x12\x10\n\x06svalue\x18\x01 \x01(\tH\x00\x12\x10\n\x06ivalue\x18\x02 \x01(\x03H\x00\x12\x10\n\x06\x66value\x18\x03 \x01(\x02H\x00\x12\x10\n\x06\x62value\x18\x04 \x01(\x08H\x00\x42\x0e\n\x0coneof_values\"\xbb\x01\n\x13SingleStringRequest\x12\x0f\n\x07request\x18\x01 \x01(\t\x12I\n\x0cquery_kwargs\x18\x02 \x03(\x0b\x32\x33.modelresponse.SingleStringRequest.QueryKwargsEntry\x1aH\n\x10QueryKwargsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.modelresponse.Value:\x02\x38\x01\"\xb9\x01\n\x12MultiStringRequest\x12\x0f\n\x07request\x18\x01 \x03(\t\x12H\n\x0cquery_kwargs\x18\x02 \x03(\x0b\x32\x32.modelresponse.MultiStringRequest.QueryKwargsEntry\x1aH\n\x10QueryKwargsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.modelresponse.Value:\x02\x38\x01\"9\n\x11SingleStringReply\x12\x10\n\x08response\x18\x01 \x01(\t\x12\x12\n\ntime_taken\x18\x02 \x01(\x02\"8\n\x10MultiStringReply\x12\x10\n\x08response\x18\x01 \x03(\t\x12\x12\n\ntime_taken\x18\x02 \x01(\x02\"\xb9\x01\n\tQARequest\x12\x10\n\x08question\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontext\x18\x02 \x01(\t\x12?\n\x0cquery_kwargs\x18\x03 \x03(\x0b\x32).modelresponse.QARequest.QueryKwargsEntry\x1aH\n\x10QueryKwargsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.modelresponse.Value:\x02\x38\x01\"\xa1\x02\n\x13\x43onversationRequest\x12\x0c\n\x04text\x18\x01 \x01(\t\x12\x1c\n\x0f\x63onversation_id\x18\x02 \x01(\x03H\x00\x88\x01\x01\x12\x18\n\x10past_user_inputs\x18\x03 \x03(\t\x12\x1b\n\x13generated_responses\x18\x04 \x03(\t\x12I\n\x0cquery_kwargs\x18\x05 \x03(\x0b\x32\x33.modelresponse.ConversationRequest.QueryKwargsEntry\x1aH\n\x10QueryKwargsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.modelresponse.Value:\x02\x38\x01\x42\x12\n\x10_conversation_id\"w\n\x11\x43onversationReply\x12\x17\n\x0f\x63onversation_id\x18\x01 \x01(\x03\x12\x18\n\x10past_user_inputs\x18\x02 \x03(\t\x12\x1b\n\x13generated_responses\x18\x03 \x03(\t\x12\x12\n\ntime_taken\x18\x04 \x01(\x02\x32\xba\x04\n\rModelResponse\x12V\n\x0eGeneratorReply\x12!.modelresponse.MultiStringRequest\x1a\x1f.modelresponse.MultiStringReply\"\x00\x12]\n\x13\x43lassificationReply\x12\".modelresponse.SingleStringRequest\x1a .modelresponse.SingleStringReply\"\x00\x12V\n\x16QuestionAndAnswerReply\x12\x18.modelresponse.QARequest\x1a .modelresponse.SingleStringReply\"\x00\x12W\n\rFillMaskReply\x12\".modelresponse.SingleStringRequest\x1a .modelresponse.SingleStringReply\"\x00\x12\x62\n\x18TokenClassificationReply\x12\".modelresponse.SingleStringRequest\x1a .modelresponse.SingleStringReply\"\x00\x12]\n\x13\x43onversationalReply\x12\".modelresponse.ConversationRequest\x1a .modelresponse.ConversationReply\"\x00\x62\x06proto3'
+    b'\n\x13modelresponse.proto\x12\rmodelresponse\"_\n\x05Value\x12\x10\n\x06svalue\x18\x01 \x01(\tH\x00\x12\x10\n\x06ivalue\x18\x02 \x01(\x03H\x00\x12\x10\n\x06\x66value\x18\x03 \x01(\x02H\x00\x12\x10\n\x06\x62value\x18\x04 \x01(\x08H\x00\x42\x0e\n\x0coneof_values\"\xbb\x01\n\x13SingleStringRequest\x12\x0f\n\x07request\x18\x01 \x01(\t\x12I\n\x0cquery_kwargs\x18\x02 \x03(\x0b\x32\x33.modelresponse.SingleStringRequest.QueryKwargsEntry\x1aH\n\x10QueryKwargsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.modelresponse.Value:\x02\x38\x01\"\xb9\x01\n\x12MultiStringRequest\x12\x0f\n\x07request\x18\x01 \x03(\t\x12H\n\x0cquery_kwargs\x18\x02 \x03(\x0b\x32\x32.modelresponse.MultiStringRequest.QueryKwargsEntry\x1aH\n\x10QueryKwargsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.modelresponse.Value:\x02\x38\x01\"S\n\x11SingleStringReply\x12\x10\n\x08response\x18\x01 \x01(\t\x12\x12\n\ntime_taken\x18\x02 \x01(\x02\x12\x18\n\x10model_time_taken\x18\x03 \x01(\x02\"R\n\x10MultiStringReply\x12\x10\n\x08response\x18\x01 \x03(\t\x12\x12\n\ntime_taken\x18\x02 \x01(\x02\x12\x18\n\x10model_time_taken\x18\x03 \x01(\x02\"\xb9\x01\n\tQARequest\x12\x10\n\x08question\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontext\x18\x02 \x01(\t\x12?\n\x0cquery_kwargs\x18\x03 \x03(\x0b\x32).modelresponse.QARequest.QueryKwargsEntry\x1aH\n\x10QueryKwargsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.modelresponse.Value:\x02\x38\x01\"\xa1\x02\n\x13\x43onversationRequest\x12\x0c\n\x04text\x18\x01 \x01(\t\x12\x1c\n\x0f\x63onversation_id\x18\x02 \x01(\x03H\x00\x88\x01\x01\x12\x18\n\x10past_user_inputs\x18\x03 \x03(\t\x12\x1b\n\x13generated_responses\x18\x04 \x03(\t\x12I\n\x0cquery_kwargs\x18\x05 \x03(\x0b\x32\x33.modelresponse.ConversationRequest.QueryKwargsEntry\x1aH\n\x10QueryKwargsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.modelresponse.Value:\x02\x38\x01\x42\x12\n\x10_conversation_id\"\x91\x01\n\x11\x43onversationReply\x12\x17\n\x0f\x63onversation_id\x18\x01 \x01(\x03\x12\x18\n\x10past_user_inputs\x18\x02 \x03(\t\x12\x1b\n\x13generated_responses\x18\x03 \x03(\t\x12\x12\n\ntime_taken\x18\x04 \x01(\x02\x12\x18\n\x10model_time_taken\x18\x05 \x01(\x02\x32\xba\x04\n\rModelResponse\x12V\n\x0eGeneratorReply\x12!.modelresponse.MultiStringRequest\x1a\x1f.modelresponse.MultiStringReply\"\x00\x12]\n\x13\x43lassificationReply\x12\".modelresponse.SingleStringRequest\x1a .modelresponse.SingleStringReply\"\x00\x12V\n\x16QuestionAndAnswerReply\x12\x18.modelresponse.QARequest\x1a .modelresponse.SingleStringReply\"\x00\x12W\n\rFillMaskReply\x12\".modelresponse.SingleStringRequest\x1a .modelresponse.SingleStringReply\"\x00\x12\x62\n\x18TokenClassificationReply\x12\".modelresponse.SingleStringRequest\x1a .modelresponse.SingleStringReply\"\x00\x12]\n\x13\x43onversationalReply\x12\".modelresponse.ConversationRequest\x1a .modelresponse.ConversationReply\"\x00\x62\x06proto3'
 )
 
 _VALUE = DESCRIPTOR.message_types_by_name['Value']
@@ -192,19 +192,19 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _MULTISTRINGREQUEST_QUERYKWARGSENTRY._serialized_start = 251
     _MULTISTRINGREQUEST_QUERYKWARGSENTRY._serialized_end = 323
     _SINGLESTRINGREPLY._serialized_start = 513
-    _SINGLESTRINGREPLY._serialized_end = 570
-    _MULTISTRINGREPLY._serialized_start = 572
-    _MULTISTRINGREPLY._serialized_end = 628
-    _QAREQUEST._serialized_start = 631
-    _QAREQUEST._serialized_end = 816
+    _SINGLESTRINGREPLY._serialized_end = 596
+    _MULTISTRINGREPLY._serialized_start = 598
+    _MULTISTRINGREPLY._serialized_end = 680
+    _QAREQUEST._serialized_start = 683
+    _QAREQUEST._serialized_end = 868
     _QAREQUEST_QUERYKWARGSENTRY._serialized_start = 251
     _QAREQUEST_QUERYKWARGSENTRY._serialized_end = 323
-    _CONVERSATIONREQUEST._serialized_start = 819
-    _CONVERSATIONREQUEST._serialized_end = 1108
+    _CONVERSATIONREQUEST._serialized_start = 871
+    _CONVERSATIONREQUEST._serialized_end = 1160
     _CONVERSATIONREQUEST_QUERYKWARGSENTRY._serialized_start = 251
     _CONVERSATIONREQUEST_QUERYKWARGSENTRY._serialized_end = 323
-    _CONVERSATIONREPLY._serialized_start = 1110
-    _CONVERSATIONREPLY._serialized_end = 1229
-    _MODELRESPONSE._serialized_start = 1232
-    _MODELRESPONSE._serialized_end = 1802
+    _CONVERSATIONREPLY._serialized_start = 1163
+    _CONVERSATIONREPLY._serialized_end = 1308
+    _MODELRESPONSE._serialized_start = 1311
+    _MODELRESPONSE._serialized_end = 1881
 # @@protoc_insertion_point(module_scope)

--- a/mii/models/load_models.py
+++ b/mii/models/load_models.py
@@ -5,6 +5,7 @@ import os
 import mii
 import json
 import torch
+import inspect
 import deepspeed
 from deepspeed.runtime.config import DeepSpeedConfig
 from deepspeed.runtime.zero.config import ZeroStageEnum
@@ -22,11 +23,7 @@ def load_models(task_name,
     world_size = int(os.getenv('WORLD_SIZE', '1'))
 
     #TODO: pass in mii_config to fetch dtype, training_mp_size, and other params
-
-    checkpoint = None
-    mpu = None
-    args = None
-    training_mp_size = 1
+    ds_kwargs = {"checkpoint": None, "mpu": None, "args": None, "training_mp_size": 1}
     if provider == mii.constants.ModelProvider.HUGGING_FACE:
         from mii.models.providers.huggingface import hf_provider
         inference_pipeline = hf_provider(model_path, model_name, task_name, mii_config)
@@ -35,18 +32,23 @@ def load_models(task_name,
         assert mii_config.torch_dtype() == torch.half, "gpt-neox only support fp16"
         assert mii_config.enable_cuda_graph == False, "Provider EleutherAI not supported with Cuda Graphs"
         from megatron import mpu
+        ds_kwargs["mpu"] = mpu
         inference_pipeline = eleutherai_provider(model_path,
                                                  model_name,
                                                  task_name,
                                                  mii_config)
-        training_mp_size = 2
-        args = inference_pipeline.neox_args
+        ds_kwargs["training_mp_size"] = 2
+        ds_kwargs["args"] = inference_pipeline.neox_args
     elif provider == mii.constants.ModelProvider.HUGGING_FACE_LLM:
         from mii.models.providers.llm import load_hf_llm
-        assert mii_config.torch_dtype() == torch.half, "Bloom models only support fp16"
+        assert mii_config.torch_dtype() == torch.half or mii_config.torch_dtype() == torch.int8, "Bloom models only support fp16/int8"
         assert mii_config.enable_cuda_graph == False, "Bloom models do no support Cuda Graphs"
         inference_pipeline = load_hf_llm(model_path, model_name, task_name, mii_config)
-        checkpoint = inference_pipeline.checkpoint_dict
+        ds_kwargs["checkpoint"] = inference_pipeline.checkpoint_dict
+        if mii_config.torch_dtype() == torch.int8:
+            if "enable_qkv_quantization" in inspect.signature(
+                    deepspeed.init_inference).parameters:
+                ds_kwargs["enable_qkv_quantization"] = True
     else:
         raise ValueError(f"Unknown model provider {provider}")
 
@@ -54,14 +56,13 @@ def load_models(task_name,
         inference_pipeline.model = deepspeed.init_inference(
             inference_pipeline.model,
             mp_size=world_size,
-            training_mp_size=training_mp_size,
-            mpu=mpu,
-            checkpoint=checkpoint,
             dtype=mii_config.torch_dtype(),
-            replace_with_kernel_inject=True,
+            replace_with_kernel_inject=mii_config.replace_with_kernel_inject,
             replace_method='auto',
             enable_cuda_graph=mii_config.enable_cuda_graph,
-            args=args)
+            **ds_kwargs)
+        if mii_config.profile_model_time:
+            inference_pipeline.model.profile_model_time()
     elif ds_zero:
         ds_config = DeepSpeedConfig(ds_config_path)
         #TODO: don't read ds-config from disk, we should pass this around as a dict instead

--- a/mii/models/load_models.py
+++ b/mii/models/load_models.py
@@ -52,6 +52,9 @@ def load_models(task_name,
     else:
         raise ValueError(f"Unknown model provider {provider}")
 
+    print(
+        f"> --------- MII Settings: {ds_optimize=}, replace_with_kernel_inject={mii_config.replace_with_kernel_inject}, enable_cuda_graph={mii_config.enable_cuda_graph} "
+    )
     if ds_optimize:
         inference_pipeline.model = deepspeed.init_inference(
             inference_pipeline.model,

--- a/mii/models/providers/llm.py
+++ b/mii/models/providers/llm.py
@@ -3,6 +3,7 @@ import torch
 import deepspeed
 from deepspeed.inference.engine import InferenceEngine
 from deepspeed import OnDevice
+from mii.utils import mii_cache_path
 
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
 from transformers.utils import WEIGHTS_NAME, WEIGHTS_INDEX_NAME, cached_path, hf_bucket_url
@@ -34,6 +35,7 @@ class BloomPipeline(object):
         for t in tokens:
             if torch.is_tensor(tokens[t]):
                 tokens[t] = tokens[t].to(f'cuda:{local_rank}')
+
         greedy_output = self.model.generate(**tokens, **kwargs)
         outputs = self.tokenizer.batch_decode(greedy_output, skip_special_tokens=True)
 
@@ -101,15 +103,32 @@ def create_checkpoint_dict(model_name, model_path, mii_config):
         return data
 
 
+def _attempt_load(load_fn, model_name, cache_path, kwargs={}):
+    try:
+        value = load_fn(model_name, **kwargs)
+    except OSError:
+        print(f'Attempted load but failed, retrying using cache_dir={cache_path}')
+        value = load_fn(model_name, cache_dir=cache_path, **kwargs)
+    return value
+
+
 # TODO: This function is a hack for the Bloom models and will be replaced with a LargeModel provider code path
 def load_hf_llm(model_path, model_name, task_name, mii_config):
     deepspeed.init_distributed('nccl')
     local_rank = int(os.getenv('LOCAL_RANK', '0'))
     world_size = int(os.getenv('WORLD_SIZE', '1'))
 
-    tokenizer = AutoTokenizer.from_pretrained(model_name)
-    config = AutoConfig.from_pretrained(model_name)
-    with OnDevice(dtype=torch.float16, enabled=True):
+    cache_path = mii_cache_path()
+
+    tokenizer = _attempt_load(AutoTokenizer.from_pretrained,
+                              model_name,
+                              cache_path,
+                              kwargs={"padding_side": 'left'})
+    tokenizer.pad_token = tokenizer.eos_token
+
+    config = _attempt_load(AutoConfig.from_pretrained, model_name, cache_path)
+
+    with OnDevice(dtype=torch.float16, device='meta', enabled=True):
         model = AutoModelForCausalLM.from_config(config, torch_dtype=torch.bfloat16)
     model = model.eval()
     checkpoint_dict = create_checkpoint_dict(model_name, model_path, mii_config)


### PR DESCRIPTION
* Exposes two ds-inference parameters: replace_with_kernel_inject and profile_model_time
* Allows float32/16 dtype names
* Adds opt support mapped to HF provider
* Collapse all DS kwargs into single dict
* Allow bloom-176b w. int8
* Iff DS supports enable_qkv_quantization set it to true for bloom-176b
* Update bloom-176b tokenizer to use padding side left and pad token
* Copied changes from #45 into this PR, they are not always needed but still a nice usability feature