### PR TITLE
update txt2img example to sd 1.5

### DIFF
--- a/examples/local/txt2img-example.py
+++ b/examples/local/txt2img-example.py
@@ -19,7 +19,7 @@ if not args.query:
         50050
     }
     mii.deploy(task='text-to-image',
-               model="CompVis/stable-diffusion-v1-4",
+               model="runwayml/stable-diffusion-v1-5",
                deployment_name="sd_deploy",
                mii_config=mii_configs)
     print(


### PR DESCRIPTION
Stable Diffusion has been updated to 1.5 in the Diffusers library, and the model is now hosted via RunwayML (1.4 was hosted by CompVis)

Model card is here:
https://huggingface.co/runwayml/stable-diffusion-v1-5

This PR updates the example to the new version, which is considered to be more SFW and has better face quality.