### PR TITLE
fix(example): QnA model name

### DIFF
--- a/examples/local/question-answering-query-example.py
+++ b/examples/local/question-answering-query-example.py
@@ -2,7 +2,7 @@ import mii
 
 name = "deepset/roberta-large-squad2"
 
-generator = mii.mii_query_handle(name + "_deployment")
+generator = mii.mii_query_handle(name + "-qa-deployment")
 results = generator.query({
     'question': "What is the greatest?",
     'context': "DeepSpeed is the greatest"


### PR DESCRIPTION
In the [deployment step](https://github.com/microsoft/DeepSpeed-MII/blob/main/examples/local/question-answering-example.py#L8) the model is named `name + "-qa-deployment"` (not `name + "_deployment"`).