### PR TITLE
bump min deepspeed to 0.7.4

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 asyncio
-deepspeed>=0.6.7
+deepspeed>=0.7.4
 grpcio
 grpcio-tools
 pydantic


### PR DESCRIPTION
text2image deployments require deepspeed >= 0.7.4

fixes #78 