### PR TITLE
Improvements to VRAM usage when loading HF models

### DIFF
--- a/mii/deployment.py
+++ b/mii/deployment.py
@@ -65,9 +65,9 @@ def deploy(task,
     mii_config = mii.config.MIIConfig(**mii_config)
     if enable_zero:
         if ds_config.get("fp16", {}).get("enabled", False):
-            assert (mii_config.torch_dtype() == torch.half), "MII Config Error: MII dtype and ZeRO dtype must match"
+            assert (mii_config.dtype == torch.half), "MII Config Error: MII dtype and ZeRO dtype must match"
         else:
-            assert (mii_config.torch_dtype() == torch.float), "MII Config Error: MII dtype and ZeRO dtype must match"
+            assert (mii_config.dtype == torch.float), "MII Config Error: MII dtype and ZeRO dtype must match"
     assert not (enable_deepspeed and enable_zero), "MII Config Error: DeepSpeed and ZeRO cannot both be enabled, select only one"
 
     # aml only allows certain characters for deployment names

--- a/mii/models/load_models.py
+++ b/mii/models/load_models.py
@@ -28,7 +28,7 @@ def load_models(task_name,
             "tp_size": world_size,
             "mpu": None
         },
-        "dtype": mii_config.torch_dtype(),
+        "dtype": mii_config.dtype,
         "replace_method": "auto",
         "enable_cuda_graph": mii_config.enable_cuda_graph,
         "checkpoint": None,
@@ -58,7 +58,7 @@ def load_models(task_name,
         assert mii_config.enable_cuda_graph == False, "Bloom models do no support Cuda Graphs"
         inference_pipeline = load_hf_llm(model_path, model_name, task_name, mii_config)
         inf_config["checkpoint"] = inference_pipeline.checkpoint_dict
-        if mii_config.torch_dtype() == torch.int8:
+        if mii_config.dtype == torch.int8:
             if "enable_qkv_quantization" in inspect.signature(
                     deepspeed.init_inference).parameters:
                 inf_config["enable_qkv_quantization"] = True

--- a/mii/models/providers/diffusers.py
+++ b/mii/models/providers/diffusers.py
@@ -7,7 +7,7 @@ def diffusers_provider(model_path, model_name, task_name, mii_config):
     local_rank = int(os.getenv('LOCAL_RANK', '0'))
 
     kwargs = {}
-    if mii_config.torch_dtype() == torch.half:
+    if mii_config.dtype == torch.half:
         kwargs["torch_dtype"] = torch.float16
         kwargs["revision"] = "fp16"
 

--- a/mii/models/providers/huggingface.py
+++ b/mii/models/providers/huggingface.py
@@ -1,17 +1,18 @@
 import os
-import torch
 from transformers import pipeline
 
 
 def hf_provider(model_path, model_name, task_name, mii_config):
-    local_rank = int(os.getenv('LOCAL_RANK', '0'))
+    if mii_config.load_with_sys_mem:
+        local_rank = -1
+    else:
+        local_rank = int(os.getenv('LOCAL_RANK', '0'))
     inference_pipeline = pipeline(
         task_name,
         model=model_name,
         device=local_rank,
         framework="pt",
         use_auth_token=mii_config.hf_auth_token,
+        torch_dtype=mii_config.dtype,
     )
-    if mii_config.torch_dtype() == torch.half:
-        inference_pipeline.model.half()
     return inference_pipeline

--- a/mii/models/score/score_template.py
+++ b/mii/models/score/score_template.py
@@ -4,6 +4,7 @@ Copyright 2022 The Microsoft DeepSpeed Team
 '''
 import os
 import json
+import torch
 import mii
 import time
 


### PR DESCRIPTION
MII can now optionally load models onto system memory initially with the `load_with_sys_mem` option added to the config. This solves a problem when the model takes up nearly all the GPU memory and performing kernel injection requires some additional space, causing OOM errors despite there being enough GPU memory to hold the model.

Also adding the `DTypeEnum` from DeepSpeed to the MII config and unit tests to test this new option