### PR TITLE
Support text2text-generation pipelines and T5 models in particular

### DIFF
--- a/examples/local/text-generation-flan-example.py
+++ b/examples/local/text-generation-flan-example.py
@@ -1,0 +1,7 @@
+import mii
+
+mii_configs = {"tensor_parallel": 1, "dtype": "fp16"}
+mii.deploy(task='text2text-generation',
+           model="google/flan-t5-small",
+           deployment_name="flan_deployment",
+           mii_config=mii_configs)

--- a/examples/local/text-generation-flan-query-example.py
+++ b/examples/local/text-generation-flan-query-example.py
@@ -1,0 +1,16 @@
+import mii
+
+print(f"Querying flan...")
+
+str = "Tell me why DeepSpeed is the greatest."
+
+generator = mii.mii_query_handle("flan_deployment")
+result = generator.query({
+    'query': str,
+    'conversation_id': 1,
+    'past_user_inputs': [],
+    'generated_responses': []
+})
+
+print(result)
+print(f"time_taken: {result.time_taken}")

--- a/mii/constants.py
+++ b/mii/constants.py
@@ -18,9 +18,11 @@ class Tasks(enum.Enum):
     TOKEN_CLASSIFICATION = 5
     CONVERSATIONAL = 6
     TEXT2IMG = 7
+    TEXT2TEXT_GENERATION = 8
 
 
 TEXT_GENERATION_NAME = 'text-generation'
+TEXT2TEXT_GENERATION_NAME = 'text2text-generation'
 TEXT_CLASSIFICATION_NAME = 'text-classification'
 QUESTION_ANSWERING_NAME = 'question-answering'
 FILL_MASK_NAME = 'fill-mask'
@@ -58,7 +60,8 @@ SUPPORTED_MODEL_TYPES = {
     'opt': ModelProvider.HUGGING_FACE,
     'gpt-neox': ModelProvider.ELEUTHER_AI,
     'bloom': ModelProvider.HUGGING_FACE_LLM,
-    'stable-diffusion': ModelProvider.DIFFUSERS
+    'stable-diffusion': ModelProvider.DIFFUSERS,
+    't5': ModelProvider.HUGGING_FACE,
 }
 
 SUPPORTED_TASKS = [

--- a/mii/grpc_related/modelresponse_server.py
+++ b/mii/grpc_related/modelresponse_server.py
@@ -54,10 +54,15 @@ class ModelResponse(modelresponse_pb2_grpc.ModelResponseServicer):
         batched_responses = self.inference_pipeline(request, **query_kwargs)
         end = time.time()
 
-        # response is a list
         text_responses = []
         for response in batched_responses:
-            text = response[0]['generated_text']
+            # response is a list for TextGeneration and a dict for Text2TextGeneration.
+            if isinstance(response, list):
+                text = response[0]['generated_text']
+            elif isinstance(response, dict):
+                text = response['generated_text']
+            else:
+                raise ValueError('Expected response to be a list or dict')
             text_responses.append(text)
 
         model_time = self._get_model_time(self.inference_pipeline.model, sum_times=True)

--- a/mii/grpc_related/modelresponse_server.py
+++ b/mii/grpc_related/modelresponse_server.py
@@ -63,6 +63,7 @@ class ModelResponse(modelresponse_pb2_grpc.ModelResponseServicer):
                 text = response['generated_text']
             else:
                 raise ValueError('Expected response to be a list or dict')
+
             text_responses.append(text)
 
         model_time = self._get_model_time(self.inference_pipeline.model, sum_times=True)

--- a/mii/server_client.py
+++ b/mii/server_client.py
@@ -312,6 +312,14 @@ class MIIServerClient():
                                                        query_kwargs=proto_kwargs)
             response = await self.stubs[stub_id].Txt2ImgReply(req)
 
+        elif self.task == mii.Tasks.TEXT2TEXT_GENERATION:
+            # convert to batch of queries if they are not already
+            if not isinstance(request_dict['query'], list):
+                request_dict['query'] = [request_dict['query']]
+            req = modelresponse_pb2.MultiStringRequest(request=request_dict['query'],
+                                                       query_kwargs=proto_kwargs)
+            response = await self.stubs[stub_id].GeneratorReply(req)
+
         else:
             raise ValueError(f"unknown task: {self.task}")
         return response

--- a/mii/utils.py
+++ b/mii/utils.py
@@ -20,7 +20,8 @@ from mii.constants import (CONVERSATIONAL_NAME,
                            SUPPORTED_MODEL_TYPES,
                            ModelProvider,
                            REQUIRED_KEYS_PER_TASK,
-                           TEXT2IMG_NAME)
+                           TEXT2IMG_NAME,
+                           TEXT2TEXT_GENERATION_NAME)
 
 from mii.constants import Tasks
 
@@ -47,6 +48,9 @@ def get_task_name(task):
     if task == Tasks.TEXT2IMG:
         return TEXT2IMG_NAME
 
+    if task == Tasks.TEXT2TEXT_GENERATION:
+        return TEXT2TEXT_GENERATION_NAME
+
     raise ValueError(f"Unknown Task {task}")
 
 
@@ -72,6 +76,8 @@ def get_task(task_name):
     if task_name == TEXT2IMG_NAME:
         return Tasks.TEXT2IMG
 
+    if task_name == TEXT2TEXT_GENERATION_NAME:
+        return Tasks.TEXT2TEXT_GENERATION
     assert False, f"Unknown Task {task_name}"
 
 

--- a/mii/utils.py
+++ b/mii/utils.py
@@ -78,6 +78,7 @@ def get_task(task_name):
 
     if task_name == TEXT2TEXT_GENERATION_NAME:
         return Tasks.TEXT2TEXT_GENERATION
+
     assert False, f"Unknown Task {task_name}"
 
 


### PR DESCRIPTION
**Summary**
Support the T5 family of models on Huggingface. Additionally, since the T5 models use the `text2text-generation` pipelines on Huggingface, this PR adds support for `text2text-generation` pipelines. Because the `text2text-generation` pipelines are conceptually very similar to `text-generation` pipelines, this PR uses the same `GeneratorReply` stub for model serving.

**Linked Issues**
Addresses https://github.com/microsoft/DeepSpeed-MII/issues/106

**Usage guide**
```commandline
❯ python examples/local/text-generation-flan-example.py
❯ python examples/local/text-generation-flan-query-example.py
Querying flan...
response: "DeepSpeed is the fastest and most reliable speed of the ethernet."
time_taken: 0.546296835
model_time_taken: -1

time_taken: 0.5462968349456787
```