### PR TITLE
Separate server and client

### DIFF
--- a/mii/__init__.py
+++ b/mii/__init__.py
@@ -1,5 +1,6 @@
 import grpc
-from .server_client import MIIServerClient, mii_query_handle
+from .server import MIIServer
+from .client import MIIClient, mii_query_handle
 from .deployment import deploy
 from .terminate import terminate
 from .constants import DeploymentType, Tasks

--- a/mii/client.py
+++ b/mii/client.py
@@ -1,0 +1,168 @@
+'''
+Copyright 2022 The Microsoft DeepSpeed Team
+'''
+import asyncio
+import time
+import grpc
+import mii
+from mii.utils import get_num_gpus
+from mii.grpc_related.proto import modelresponse_pb2_grpc
+from mii.constants import GRPC_MAX_MSG_SIZE
+from mii.method_table import GRPC_METHOD_TABLE
+
+
+def mii_query_handle(deployment_name):
+    """Get a query handle for a local deployment:
+
+        mii/examples/local/gpt2-query-example.py
+        mii/examples/local/roberta-qa-query-example.py
+
+
+    Arguments:
+        deployment_name: Name of the deployment. Used as an identifier for posting queries for ``LOCAL`` deployment.
+
+    Returns:
+        query_handle: A query handle with a single method `.query(request_dictionary)` using which queries can be sent to the model.
+
+    """
+
+    configs = mii.utils.import_score_file(deployment_name).configs
+
+    task = configs[mii.constants.TASK_NAME_KEY]
+
+    assert task is not None, "The task name should be set before calling init"
+
+    return mii.MIIClient(task,
+                         mii_configs=configs[mii.constants.MII_CONFIGS_KEY],
+                         initialize_service=False,
+                         initialize_grpc_client=True,
+                         use_grpc_server=True)
+
+
+class MIIClient():
+    '''Initialize the model, setup the server and client for the model under model_path'''
+    def __init__(self,
+                 task_name,
+                 mii_configs={},
+                 initialize_service=True,
+                 initialize_grpc_client=True,
+                 use_grpc_server=False):
+
+        mii_configs = mii.config.MIIConfig(**mii_configs)
+
+        self.task = mii.utils.get_task(task_name)
+
+        self.num_gpus = get_num_gpus(mii_configs)
+        assert self.num_gpus > 0, "GPU count must be greater than 0"
+
+        # This is true in two cases
+        # i) If its multi-GPU
+        # ii) It is a local deployment
+        self.use_grpc_server = True if (self.num_gpus > 1) else use_grpc_server
+        self.initialize_grpc_client = initialize_grpc_client
+
+        self.port_number = mii_configs.port_number
+
+        if initialize_service and not self.use_grpc_server:
+            self.model = None
+
+        if self.initialize_grpc_client and self.use_grpc_server:
+            self.stubs = []
+            self.asyncio_loop = asyncio.get_event_loop()
+            self._initialize_grpc_client()
+
+    def _initialize_grpc_client(self):
+        channels = []
+        for i in range(self.num_gpus):
+            channel = grpc.aio.insecure_channel(f'localhost:{self.port_number + i}',
+                                                options=[
+                                                    ('grpc.max_send_message_length',
+                                                     GRPC_MAX_MSG_SIZE),
+                                                    ('grpc.max_receive_message_length',
+                                                     GRPC_MAX_MSG_SIZE)
+                                                ])
+            stub = modelresponse_pb2_grpc.ModelResponseStub(channel)
+            channels.append(channel)
+            self.stubs.append(stub)
+
+    # runs task in parallel and return the result from the first task
+    async def _query_in_tensor_parallel(self, request_string, query_kwargs):
+        responses = []
+        for i in range(self.num_gpus):
+            responses.append(
+                self.asyncio_loop.create_task(
+                    self._request_async_response(i,
+                                                 request_string,
+                                                 query_kwargs)))
+
+        await responses[0]
+
+        return responses[0]
+
+    async def _request_async_response(self, stub_id, request_dict, query_kwargs):
+        if self.task not in GRPC_METHOD_TABLE:
+            raise ValueError(f"unknown task: {self.task}")
+
+        conversions = GRPC_METHOD_TABLE[self.task]
+        proto_request = conversions["pack_request_to_proto"](request_dict,
+                                                             **query_kwargs)
+        proto_response = await getattr(self.stubs[stub_id],
+                                       conversions["method"])(proto_request)
+        return conversions["unpack_response_from_proto"](
+            proto_response
+        ) if "unpack_response_from_proto" in conversions else proto_response
+
+    def _request_response(self, request_dict, query_kwargs):
+        start = time.time()
+        if self.task == mii.Tasks.TEXT_GENERATION:
+            response = self.model(request_dict['query'], **query_kwargs)
+
+        elif self.task == mii.Tasks.TEXT_CLASSIFICATION:
+            response = self.model(request_dict['query'], **query_kwargs)
+
+        elif self.task == mii.Tasks.QUESTION_ANSWERING:
+            response = self.model(question=request_dict['query'],
+                                  context=request_dict['context'],
+                                  **query_kwargs)
+
+        elif self.task == mii.Tasks.FILL_MASK:
+            response = self.model(request_dict['query'], **query_kwargs)
+
+        elif self.task == mii.Tasks.TOKEN_CLASSIFICATION:
+            response = self.model(request_dict['query'], **query_kwargs)
+
+        elif self.task == mii.Tasks.CONVERSATIONAL:
+            response = self.model(["", request_dict['query']], **query_kwargs)
+
+        elif self.task == mii.Tasks.TEXT2IMG:
+            response = self.model(request_dict['query'], **query_kwargs)
+
+        else:
+            raise NotImplementedError(f"task is not supported: {self.task}")
+        end = time.time()
+        return f"{response}" + f"\n Model Execution Time: {end-start} seconds"
+
+    def query(self, request_dict, **query_kwargs):
+        """Query a local deployment:
+
+            mii/examples/local/gpt2-query-example.py
+            mii/examples/local/roberta-qa-query-example.py
+
+        Arguments:
+            request_dict: A task specific request dictionary consistinging of the inputs to the models
+            query_kwargs: additional query parameters for the model
+
+        Returns:
+            response: Response of the model
+        """
+        if not self.use_grpc_server:
+            response = self._request_response(request_dict, query_kwargs)
+            ret = f"{response}"
+        else:
+            assert self.initialize_grpc_client, "grpc client has not been setup when this model was created"
+            response = self.asyncio_loop.run_until_complete(
+                self._query_in_tensor_parallel(request_dict,
+                                               query_kwargs))
+            ret = response.result()
+
+        return ret

--- a/mii/models/score/score_template.py
+++ b/mii/models/score/score_template.py
@@ -26,16 +26,19 @@ def init():
     assert model_name is not None, "The model name should be set before calling init"
     assert task is not None, "The task name should be set before calling init"
 
+    mii.MIIServer(task,
+                  model_name,
+                  model_path,
+                  ds_optimize=configs[mii.constants.ENABLE_DEEPSPEED_KEY],
+                  ds_zero=configs[mii.constants.ENABLE_DEEPSPEED_ZERO_KEY],
+                  ds_config=configs[mii.constants.DEEPSPEED_CONFIG_KEY],
+                  mii_configs=configs[mii.constants.MII_CONFIGS_KEY],
+                  use_grpc_server=use_grpc_server)
     global model
-    model = mii.MIIServerClient(task,
-                                model_name,
-                                model_path,
-                                ds_optimize=configs[mii.constants.ENABLE_DEEPSPEED_KEY],
-                                ds_zero=configs[mii.constants.ENABLE_DEEPSPEED_ZERO_KEY],
-                                ds_config=configs[mii.constants.DEEPSPEED_CONFIG_KEY],
-                                mii_configs=configs[mii.constants.MII_CONFIGS_KEY],
-                                use_grpc_server=use_grpc_server,
-                                initialize_grpc_client=initialize_grpc_client)
+    model = mii.MIIClient(task,
+                          mii_configs=configs[mii.constants.MII_CONFIGS_KEY],
+                          use_grpc_server=use_grpc_server,
+                          initialize_grpc_client=initialize_grpc_client)
 
 
 def run(request):

--- a/mii/models/score/score_template.py
+++ b/mii/models/score/score_template.py
@@ -38,7 +38,7 @@ def init():
 
 def run(request):
     global model
-    assert model is None, "grpc client has not been setup when this model was created"
+    assert model is not None, "grpc client has not been setup when this model was created"
 
     request_dict = json.loads(request)
 

--- a/mii/server.py
+++ b/mii/server.py
@@ -1,54 +1,19 @@
 '''
 Copyright 2022 The Microsoft DeepSpeed Team
 '''
-import asyncio
-import torch
-import sys
-import subprocess
-import time
-import grpc
-import os
-import json
-from pathlib import Path
-import mii
 import base64
-from mii.utils import logger
-from mii.grpc_related.proto import modelresponse_pb2_grpc
-from mii.constants import GRPC_MAX_MSG_SIZE
-from mii.method_table import GRPC_METHOD_TABLE
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import mii
+from mii.utils import get_num_gpus, logger
 
 
-def mii_query_handle(deployment_name):
-    """Get a query handle for a local deployment:
-
-        mii/examples/local/gpt2-query-example.py
-        mii/examples/local/roberta-qa-query-example.py
-
-
-    Arguments:
-        deployment_name: Name of the deployment. Used as an identifier for posting queries for ``LOCAL`` deployment.
-
-    Returns:
-        query_handle: A query handle with a single method `.query(request_dictionary)` using which queries can be sent to the model.
-
-    """
-
-    configs = mii.utils.import_score_file(deployment_name).configs
-
-    task = configs[mii.constants.TASK_NAME_KEY]
-
-    assert task is not None, "The task name should be set before calling init"
-
-    return mii.MIIServerClient(task,
-                               "na",
-                               "na",
-                               mii_configs=configs[mii.constants.MII_CONFIGS_KEY],
-                               initialize_service=False,
-                               initialize_grpc_client=True,
-                               use_grpc_server=True)
-
-
-class MIIServerClient():
+class MIIServer():
     '''Initialize the model, setup the server and client for the model under model_path'''
     def __init__(self,
                  task_name,
@@ -59,14 +24,13 @@ class MIIServerClient():
                  ds_config=None,
                  mii_configs={},
                  initialize_service=True,
-                 initialize_grpc_client=True,
                  use_grpc_server=False):
 
         mii_configs = mii.config.MIIConfig(**mii_configs)
 
         self.task = mii.utils.get_task(task_name)
 
-        self.num_gpus = self._get_num_gpus(mii_configs)
+        self.num_gpus = get_num_gpus(mii_configs)
         assert self.num_gpus > 0, "GPU count must be greater than 0"
 
         # This is true in two cases
@@ -74,7 +38,6 @@ class MIIServerClient():
         # ii) It is a local deployment
         self.use_grpc_server = True if (self.num_gpus > 1) else use_grpc_server
         self.initialize_service = initialize_service
-        self.initialize_grpc_client = initialize_grpc_client
 
         self.port_number = mii_configs.port_number
 
@@ -90,21 +53,6 @@ class MIIServerClient():
                                                     mii_configs)
             if self.use_grpc_server:
                 self._wait_until_server_is_live()
-
-        if self.initialize_grpc_client and self.use_grpc_server:
-            self.stubs = []
-            self.asyncio_loop = asyncio.get_event_loop()
-            self._initialize_grpc_client()
-
-    def _get_num_gpus(self, mii_configs):
-        def get_tensor_parallel_gpus(mii_configs):
-            num_gpus = mii_configs.tensor_parallel
-
-            assert torch.cuda.device_count() >= num_gpus, f"Available GPU count: {torch.cuda.device_count()} does not meet the required gpu count: {num_gpus}"
-            return num_gpus
-
-        # Only Tensor Parallelism supported for now
-        return get_tensor_parallel_gpus(mii_configs)
 
     def _wait_until_server_is_live(self):
         sockets_open = False
@@ -168,7 +116,7 @@ class MIIServerClient():
             # bytes -> str
             b64_config_str = b64_config_bytes.decode()
 
-            #TODO: will need worker hostfile support here for multi-node launching, this force ignores a /job/hostfile
+            # TODO: will need worker hostfile support here for multi-node launching, this force ignores a /job/hostfile
             #      if one exists which is not compatible when passing localhost as a hostname.
             worker_str = "-H /dev/null "
             # pin deepspeed launch to specific gpu id(s)
@@ -181,7 +129,7 @@ class MIIServerClient():
             server_args_str = f"--task-name {mii.utils.get_task_name(self.task)} --model {model_name} --model-path {model_path} --port {self.port_number}"
             server_args_str += " --ds-optimize" if ds_optimize else ""
 
-            #XXX: fetch model provider based on model name in a more general way
+            # XXX: fetch model provider based on model name in a more general way
             if model_name == "gpt-neox":
                 provider = mii.constants.MODEL_PROVIDER_NAME_EA
             elif ("bigscience/bloom" == model_name) or ("microsoft/bloom" in model_name):
@@ -235,99 +183,3 @@ class MIIServerClient():
             printable_string += f" {k} {dots} {v} \n"
         printable_string += " " + "-" * 60
         return printable_string
-
-    def _initialize_grpc_client(self):
-        channels = []
-        for i in range(self.num_gpus):
-            channel = grpc.aio.insecure_channel(f'localhost:{self.port_number + i}',
-                                                options=[
-                                                    ('grpc.max_send_message_length',
-                                                     GRPC_MAX_MSG_SIZE),
-                                                    ('grpc.max_receive_message_length',
-                                                     GRPC_MAX_MSG_SIZE)
-                                                ])
-            stub = modelresponse_pb2_grpc.ModelResponseStub(channel)
-            channels.append(channel)
-            self.stubs.append(stub)
-
-    #runs task in parallel and return the result from the first task
-    async def _query_in_tensor_parallel(self, request_string, query_kwargs):
-        responses = []
-        for i in range(self.num_gpus):
-            responses.append(
-                self.asyncio_loop.create_task(
-                    self._request_async_response(i,
-                                                 request_string,
-                                                 query_kwargs)))
-
-        await responses[0]
-
-        return responses[0]
-
-    async def _request_async_response(self, stub_id, request_dict, query_kwargs):
-        if self.task not in GRPC_METHOD_TABLE:
-            raise ValueError(f"unknown task: {self.task}")
-
-        conversions = GRPC_METHOD_TABLE[self.task]
-        proto_request = conversions["pack_request_to_proto"](request_dict,
-                                                             **query_kwargs)
-        proto_response = await getattr(self.stubs[stub_id],
-                                       conversions["method"])(proto_request)
-        return conversions["unpack_response_from_proto"](
-            proto_response
-        ) if "unpack_response_from_proto" in conversions else proto_response
-
-    def _request_response(self, request_dict, query_kwargs):
-        start = time.time()
-        if self.task == mii.Tasks.TEXT_GENERATION:
-            response = self.model(request_dict['query'], **query_kwargs)
-
-        elif self.task == mii.Tasks.TEXT_CLASSIFICATION:
-            response = self.model(request_dict['query'], **query_kwargs)
-
-        elif self.task == mii.Tasks.QUESTION_ANSWERING:
-            response = self.model(question=request_dict['query'],
-                                  context=request_dict['context'],
-                                  **query_kwargs)
-
-        elif self.task == mii.Tasks.FILL_MASK:
-            response = self.model(request_dict['query'], **query_kwargs)
-
-        elif self.task == mii.Tasks.TOKEN_CLASSIFICATION:
-            response = self.model(request_dict['query'], **query_kwargs)
-
-        elif self.task == mii.Tasks.CONVERSATIONAL:
-            response = self.model(["", request_dict['query']], **query_kwargs)
-
-        elif self.task == mii.Tasks.TEXT2IMG:
-            response = self.model(request_dict['query'], **query_kwargs)
-
-        else:
-            raise NotImplementedError(f"task is not supported: {self.task}")
-        end = time.time()
-        return f"{response}" + f"\n Model Execution Time: {end-start} seconds"
-
-    def query(self, request_dict, **query_kwargs):
-        """Query a local deployment:
-
-            mii/examples/local/gpt2-query-example.py
-            mii/examples/local/roberta-qa-query-example.py
-
-        Arguments:
-            request_dict: A task specific request dictionary consistinging of the inputs to the models
-            query_kwargs: additional query parameters for the model
-
-        Returns:
-            response: Response of the model
-        """
-        if not self.use_grpc_server:
-            response = self._request_response(request_dict, query_kwargs)
-            ret = f"{response}"
-        else:
-            assert self.initialize_grpc_client, "grpc client has not been setup when this model was created"
-            response = self.asyncio_loop.run_until_complete(
-                self._query_in_tensor_parallel(request_dict,
-                                               query_kwargs))
-            ret = response.result()
-
-        return ret

--- a/mii/utils.py
+++ b/mii/utils.py
@@ -5,6 +5,7 @@ import sys
 import os
 import logging
 import importlib
+import torch
 import mii
 
 from huggingface_hub import HfApi
@@ -197,6 +198,18 @@ def extract_query_dict(task, request_dict):
             raise ValueError("Request for task: {task} is missing required key: {key}.")
         query_dict[key] = value
     return query_dict
+
+
+def get_num_gpus(mii_configs):
+    def get_tensor_parallel_gpus(mii_configs):
+        num_gpus = mii_configs.tensor_parallel
+
+        assert torch.cuda.device_count(
+        ) >= num_gpus, f"Available GPU count: {torch.cuda.device_count()} does not meet the required gpu count: {num_gpus}"
+        return num_gpus
+
+    # Only Tensor Parallelism supported for now
+    return get_tensor_parallel_gpus(mii_configs)
 
 
 log_levels = {

--- a/mii/utils.py
+++ b/mii/utils.py
@@ -201,15 +201,11 @@ def extract_query_dict(task, request_dict):
 
 
 def get_num_gpus(mii_configs):
-    def get_tensor_parallel_gpus(mii_configs):
-        num_gpus = mii_configs.tensor_parallel
+    num_gpus = mii_configs.tensor_parallel
 
-        assert torch.cuda.device_count(
-        ) >= num_gpus, f"Available GPU count: {torch.cuda.device_count()} does not meet the required gpu count: {num_gpus}"
-        return num_gpus
-
-    # Only Tensor Parallelism supported for now
-    return get_tensor_parallel_gpus(mii_configs)
+    assert torch.cuda.device_count(
+    ) >= num_gpus, f"Available GPU count: {torch.cuda.device_count()} does not meet the required gpu count: {num_gpus}"
+    return num_gpus
 
 
 log_levels = {


### PR DESCRIPTION
Currently `MIIServerClient` works as both server and client, but they do not share much of the code.
This PR aims to split it to two different classes: MIIServer and MIIClient.
We can keep the code for each small and increase the maintainability with this change.

Regarding this change, this PR also removes the flag `use_grpc_server`.
Now gRPC is used for both LOCAL and AML settings and the flag is always set to True in `score.py`.
We can drastically simplify many conditional branches in server and client by removing the flag.