### PR TITLE
Fix condition to terminate RESTful API gateway

### DIFF
--- a/mii/client.py
+++ b/mii/client.py
@@ -136,5 +136,5 @@ class MIITensorParallelClient():
 
 def terminate_restful_gateway(deployment_name):
     _, mii_configs = _get_deployment_info(deployment_name)
-    if mii_configs.restful_api_port > 0:
+    if mii_configs.enable_restful_api:
         requests.get(f"http://localhost:{mii_configs.restful_api_port}/terminate")


### PR DESCRIPTION
The API to terminate RESTful API gateway is called when `enable_restful_api>0` but the default of `enable_restful_api` was changed to non-zero and `enable_restful_api` is now used enable RESTful API.

This fix uses `enable_restful_api` as the condition to call the termination API and prevents a call of the API when RESTful API is not enabled.