### PR TITLE
Fix kwargs passing for `conversational` tasks

### DIFF
--- a/mii/method_table.py
+++ b/mii/method_table.py
@@ -104,10 +104,8 @@ def conversational_unpack_request_from_proto(request):
     conv = Conversation(text=request.text,
                         conversation_id=request.conversation_id,
                         past_user_inputs=request.past_user_inputs,
-                        generated_responses=request.generated_responses,
-                        **kwargs)
+                        generated_responses=request.generated_responses)
     args = (conv, )
-    kwargs = {}
     return args, kwargs
 
 

--- a/tests/test_local_deployment.py
+++ b/tests/test_local_deployment.py
@@ -153,7 +153,7 @@ def local_deployment(deployment_config, expected_failure):
 @pytest.mark.local
 @pytest.mark.parametrize("dtype", ['fp16', 'fp32'])
 @pytest.mark.parametrize(
-    "task_name, model_name, query",
+    "task_name, model_name, query, kwargs",
     [
         (
             "conversational",
@@ -164,6 +164,21 @@ def local_deployment(deployment_config, expected_failure):
                 "past_user_inputs": [],
                 "generated_responses": [],
             },
+            {},
+        ),
+        (
+            # This tests extra kwargs being passed to the underlying model.generate() method 
+            "conversational",
+            "microsoft/DialoGPT-small",
+            {
+                "text": "DeepSpeed is the greatest",
+                "conversation_id": 3,
+                "past_user_inputs": [],
+                "generated_responses": [],
+            },
+            {
+                "do_sample": False  # This should have no effect on actual output
+            },
         ),
         (
             "fill-mask",
@@ -171,6 +186,7 @@ def local_deployment(deployment_config, expected_failure):
             {
                 "query": "Hello I'm a [MASK] model."
             },
+            {},
         ),
         (
             "question-answering",
@@ -179,6 +195,7 @@ def local_deployment(deployment_config, expected_failure):
                 "question": "What is the greatest?",
                 "context": "DeepSpeed is the greatest",
             },
+            {},
         ),
         (
             "text-generation",
@@ -186,6 +203,7 @@ def local_deployment(deployment_config, expected_failure):
             {
                 "query": ["DeepSpeed is the greatest"]
             },
+            {},
         ),
         (
             "text-generation",
@@ -194,24 +212,29 @@ def local_deployment(deployment_config, expected_failure):
                 "query": ["DeepSpeed is the greatest",
                           'Seattle is']
             },
+            {},
         ),
-        ("token-classification",
-         "Jean-Baptiste/roberta-large-ner-english",
-         {
-             "query": "My name is jean-baptiste and I live in montreal."
-         }),
+        (
+            "token-classification",
+            "Jean-Baptiste/roberta-large-ner-english",
+            {
+                "query": "My name is jean-baptiste and I live in montreal."
+            },
+            {},
+        ),
         (
             "text-classification",
             "roberta-large-mnli",
             {
                 "query": "DeepSpeed is the greatest"
             },
+            {},
         ),
     ],
 )
-def test_single_GPU(local_deployment, query):
+def test_single_GPU(local_deployment, query, kwargs):
     generator = mii.mii_query_handle(local_deployment.deployment_name)
-    result = generator.query(query)
+    result = generator.query(query, **kwargs)
     assert result
 
 

--- a/tests/test_local_deployment.py
+++ b/tests/test_local_deployment.py
@@ -167,7 +167,7 @@ def local_deployment(deployment_config, expected_failure):
             {},
         ),
         (
-            # This tests extra kwargs being passed to the underlying model.generate() method 
+            # This tests extra kwargs being passed to the underlying model.generate() method
             "conversational",
             "microsoft/DialoGPT-small",
             {


### PR DESCRIPTION
This PR fixes extra kwargs to `query` being passed to the underlying `.generate` method in the case of conversational tasks. Previously these kwargs were wired to a wrong object and causing the workload to fail.

Instead `conversational_unpack_request_from_proto` just returns `kwargs` from query proto to the caller, which will eventually be passed to `inference_pipeline`.

Updated `test_single_GPU` to cover this specific scenario as well. 