### PR TITLE
hack: add llama2 models

### DIFF
--- a/mii/config.py
+++ b/mii/config.py
@@ -3,7 +3,7 @@
 
 # DeepSpeed Team
 import torch
-from typing import Union, List
+from typing import Optional, Union, List
 from enum import Enum
 from pydantic import BaseModel, validator, root_validator
 
@@ -55,7 +55,7 @@ class MIIConfig(BaseModel):
     enable_restful_api: bool = False
     restful_api_port: int = 51080
     replica_num: int = 1
-    hostfile: str = DLTS_HOSTFILE
+    hostfile: Optional[str] = DLTS_HOSTFILE
     trust_remote_code: bool = False
 
     @validator("deploy_rank")

--- a/mii/deployment.py
+++ b/mii/deployment.py
@@ -107,9 +107,9 @@ def deploy(task,
     if mii_config.hostfile is None:
         hostfile = tempfile.NamedTemporaryFile(delete=False)
         num_gpu = torch.cuda.device_count()
-        with open(hostfile, "w") as f:
+        with open(hostfile.name, "w") as f:
             f.write(f"localhost slots={num_gpu}")
-        mii.configs.hostfile = hostfile
+        mii_config.hostfile = hostfile.name
     # add fields for replica deployment
     replica_pool = _allocate_processes(mii_config.hostfile,
                                        mii_config.tensor_parallel,

--- a/mii/server.py
+++ b/mii/server.py
@@ -47,7 +47,6 @@ class MIIServer():
         assert self.num_gpus > 0, "GPU count must be greater than 0"
 
         self.port_number = mii_configs.port_number
-
         if mii_configs.hostfile is None:
             hostfile = tempfile.NamedTemporaryFile(delete=False)
             num_gpu = torch.cuda.device_count()

--- a/mii/server.py
+++ b/mii/server.py
@@ -50,9 +50,9 @@ class MIIServer():
         if mii_configs.hostfile is None:
             hostfile = tempfile.NamedTemporaryFile(delete=False)
             num_gpu = torch.cuda.device_count()
-            with open(hostfile, "w") as f:
+            with open(hostfile.name, "w") as f:
                 f.write(f"localhost slots={num_gpu}")
-            mii.configs.hostfile = hostfile
+            mii_configs.hostfile = hostfile.name
 
         processes = self._initialize_service(deployment_name,
                                              model_name,

--- a/mii/utils.py
+++ b/mii/utils.py
@@ -83,9 +83,16 @@ def _get_hf_models_by_type(model_type, task=None):
               if task is None else [m.modelId for m in models if m.pipeline_tag == task])
     if task == TEXT_GENERATION_NAME:
         # TODO: this is a temp solution to get around some HF models not having the correct tags
-        models.append("microsoft/bloom-deepspeed-inference-fp16")
-        models.append("microsoft/bloom-deepspeed-inference-int8")
-        models.append("EleutherAI/gpt-neox-20b")
+        additional_models = [
+            "microsoft/bloom-deepspeed-inference-fp16",
+            "microsoft/bloom-deepspeed-inference-int8",
+            "EleutherAI/gpt-neox-20b",
+            # note -- the llama2 models require authorization to download
+            # you may have to manually authenticate and store a token from the hf hub login() command
+            "meta-llama/Llama-2-7b-hf",
+            "meta-llama/Llama-2-13b-hf",
+        ]
+        models.extend(additional_models)
     return models
 
 


### PR DESCRIPTION
these models have the correct tags in HF but do not show up for some reason here.

Note that these require having the HF Hub token and an authorized HF account / signing Llama TOS. I also have not included the 70b model - not sure if DeepSpeed has implemented GQA yet.

I have signed the Microsoft CLA