### PR TITLE
Update Stable Diffusion to match latest DeepSpeed-Inference

### DIFF
--- a/examples/local/txt2img-example.py
+++ b/examples/local/txt2img-example.py
@@ -14,6 +14,10 @@ if not args.query:
     mii_configs = {
         "tensor_parallel":
         1,
+        "enable_cuda_graph":
+        True,
+        "replace_with_kernel_inject":
+        True,
         "dtype":
         "fp16",
         "hf_auth_token":
@@ -31,10 +35,15 @@ if not args.query:
     )
 else:
     generator = mii.mii_query_handle("sd_deploy")
+    import time
+    start = time.time()
     result = generator.query({
         'query':
         ["a panda in space with a rainbow",
          "a soda can on top a snowy mountain"]
     })
+    end = time.time()
     for idx, img in enumerate(result.images):
         img.save(f"test-{idx}.png")
+
+    print(end - start)

--- a/examples/local/txt2img-example.py
+++ b/examples/local/txt2img-example.py
@@ -35,15 +35,10 @@ if not args.query:
     )
 else:
     generator = mii.mii_query_handle("sd_deploy")
-    import time
-    start = time.time()
     result = generator.query({
         'query':
         ["a panda in space with a rainbow",
          "a soda can on top a snowy mountain"]
     })
-    end = time.time()
     for idx, img in enumerate(result.images):
         img.save(f"test-{idx}.png")
-
-    print(end - start)

--- a/mii/models/load_models.py
+++ b/mii/models/load_models.py
@@ -70,8 +70,6 @@ def load_models(task_name,
                                                 model_name,
                                                 task_name,
                                                 mii_config)
-        inf_config["replace_with_kernel_inject"] = False  #not supported yet
-        inf_config["enable_cuda_graph"] = True
     else:
         raise ValueError(f"Unknown model provider {provider}")
 


### PR DESCRIPTION
We had options like CUDA graph and kernel injections fixed in MII due to an early implementation of Stable Diffusion support in DeepSpeed-inference. Therefore the way we were standing up the Stable Diffusion pipeline was incorrect. Updating MII to match latest DeepSpeed-inference.

See https://github.com/microsoft/DeepSpeed/pull/2941