### PR TITLE
Fix for error messages in persistent deployment

### DIFF
--- a/mii/grpc_related/modelresponse_server.py
+++ b/mii/grpc_related/modelresponse_server.py
@@ -151,9 +151,14 @@ class ParallelStubInvoker:
 
     async def _invoke_async(self, method_name, proto_request):
         responses = []
-        stub = self.stubs[0]
-        method = getattr(stub, method_name)
-        responses.append(method(proto_request))
+        if method_name == TERMINATE_METHOD:
+            stubs = self.stubs
+        else:
+            stubs = [self.stubs[0]
+                     ]  # Only the first stub is used for non-terminate methods
+        for stub in stubs:
+            method = getattr(stub, method_name)
+            responses.append(method(proto_request))
         return await responses[0]
 
     def invoke(self, method_name, proto_request):

--- a/mii/grpc_related/modelresponse_server.py
+++ b/mii/grpc_related/modelresponse_server.py
@@ -151,9 +151,9 @@ class ParallelStubInvoker:
 
     async def _invoke_async(self, method_name, proto_request):
         responses = []
-        for stub in self.stubs:
-            method = getattr(stub, method_name)
-            responses.append(method(proto_request))
+        stub = self.stubs[0]
+        method = getattr(stub, method_name)
+        responses.append(method(proto_request))
         return await responses[0]
 
     def invoke(self, method_name, proto_request):


### PR DESCRIPTION
Fixes #349. We only need to return a response from rank 0 stub.

@tohtana 