### PR TITLE
Add pipeline unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ The returned `response` is a list of `Response` objects. We can access several d
 - `generated_length: int` Number of tokens generated.
 - `finish_reason: str` Reason for stopping generation. `stop` indicates the EOS token was generated and `length` indicates the generation reached `max_new_tokens` or `max_length`.
 
+If you want to free device memory and destroy the pipeline, use the `destroy` method:
+
+```python
+pipe.destroy()
+```
+
 ### Tensor parallelism
 
 Taking advantage of multi-GPU systems for greater performance is easy with MII. When run with the `deepspeed` launcher, tensor parallelism is automatically controlled by the `--num_gpus` flag:

--- a/mii/api.py
+++ b/mii/api.py
@@ -62,6 +62,9 @@ def _parse_kwargs_to_mii_config(
                               Any]] = None,
     **kwargs,
 ) -> MIIConfig:
+    if model_config is None:
+        model_config = mii_config.get("model_config", {})
+
     # Parse all model_config kwargs
     model_config, remaining_kwargs = _parse_kwargs_to_model_config(
         model_name_or_path=model_name_or_path, model_config=model_config, **kwargs
@@ -72,13 +75,7 @@ def _parse_kwargs_to_mii_config(
 
     assert isinstance(mii_config, dict), "mii_config must be a dict"
 
-    # Verify that any model_config kwargs match any existing model_config in the mii_config
-    if "model_config" in mii_config:
-        assert (
-            mii_config.get("model_config") == model_config
-        ), "mii_config['model_config'] must match model_config"
-    else:
-        mii_config["model_config"] = model_config
+    mii_config["model_config"] = model_config
 
     # Fill mii_config dict with relevant kwargs, raise error on unknown kwargs
     for key, val in remaining_kwargs.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@
 
 import pytest
 import time
-import torch
 import os
 import mii
 from types import SimpleNamespace
@@ -117,7 +116,6 @@ def mii_config(
     hostfile: str,
     model_config: dict,
 ):
-    print(f"hostfile: {hostfile}")
     config = SimpleNamespace(
         deployment_name=deployment_name,
         deployment_type=deployment_type,
@@ -144,9 +142,7 @@ def pipeline(model_config, expected_failure):
     else:
         pipe = mii.pipeline(model_config=model_config)
         yield pipe
-        del pipe.inference_engine
-        del pipe
-        torch.cuda.empty_cache()
+        pipe.destroy()
 
 
 @pytest.fixture(scope="function")
@@ -156,6 +152,7 @@ def deployment(mii_config, expected_failure):
             mii.serve(mii_config=mii_config)
         yield excinfo
     else:
+        print("CONFIG", mii_config)
         client = mii.serve(mii_config=mii_config)
         yield client
         client.terminate_server()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,7 +152,6 @@ def deployment(mii_config, expected_failure):
             mii.serve(mii_config=mii_config)
         yield excinfo
     else:
-        print("CONFIG", mii_config)
         client = mii.serve(mii_config=mii_config)
         yield client
         client.terminate_server()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+
+def test_single_gpu(pipeline, query):
+    outputs = pipeline(query)
+    assert outputs[0], "output is empty"
+
+
+def test_multi_prompt(pipeline, query):
+    outputs = pipeline([query] * 4)
+    for r in outputs:
+        assert r, "output is empty"
+
+
+def test_query_kwargs(pipeline, query):
+    # test ignore_eos
+    outputs = pipeline(
+        query,
+        max_length=128,
+        min_new_tokens=16,
+        ignore_eos=True,
+        top_p=0.9,
+        top_k=50,
+        temperature=0.9,
+    )
+    assert outputs[0], "output is empty"


### PR DESCRIPTION
- Add `destroy()` method to pipeline objects
- Add unit tests for pipeline
- Fix kwarg parsing bug, where passing a `model_config` inside a `mii_config` resulted in an empty `model_config`