### PR TITLE
Update supported models list

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ MII currently supports over 13,000 models across three popular model architectur
 
 model family | size range | ~model count
 ------ | ------ | ------
-[llama](https://huggingface.co/models?other=llama) | 7B - 65B | 11,000
-[llama-2](https://huggingface.co/models?other=llama-2) | 7B - 70B | 800
-[mistral](https://huggingface.co/models?other=mistral) | 7B | 1,100
-[opt](https://huggingface.co/models?other=opt) | 0.1B - 66B | 900
+[falcon](https://huggingface.co/models?other=llama) | 7B - 180B | 300
+[llama](https://huggingface.co/models?other=llama) | 7B - 65B | 15,000
+[llama-2](https://huggingface.co/models?other=llama-2) | 7B - 70B | 900
+[mistral](https://huggingface.co/models?other=mistral) | 7B | 3,300
+[mixtral](https://huggingface.co/models?other=mixtral) | 7B | 200
+[opt](https://huggingface.co/models?other=opt) | 0.1B - 66B | 1,100
 
 ## MII Legacy Model Support
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Under-the-hood MII is powered by [DeepSpeed-Inference](https://github.com/micros
 
 # Supported Models
 
-MII currently supports over 13,000 models across three popular model architectures. We plan to add additional models in the near term, if there are specific model architectures you would like supported please [file an issue](https://github.com/microsoft/DeepSpeed-MII/issues) and let us know. All current models leverage Hugging Face in our backend to provide both the model weights and the model's corresponding tokenizer. For our current release we support the following model architectures:
+MII currently supports over 20,000 models across three popular model architectures. We plan to add additional models in the near term, if there are specific model architectures you would like supported please [file an issue](https://github.com/microsoft/DeepSpeed-MII/issues) and let us know. All current models leverage Hugging Face in our backend to provide both the model weights and the model's corresponding tokenizer. For our current release we support the following model architectures:
 
 model family | size range | ~model count
 ------ | ------ | ------

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ MII currently supports over 20,000 models across three popular model architectur
 
 model family | size range | ~model count
 ------ | ------ | ------
-[falcon](https://huggingface.co/models?other=llama) | 7B - 180B | 300
+[falcon](https://huggingface.co/models?other=falcon) | 7B - 180B | 300
 [llama](https://huggingface.co/models?other=llama) | 7B - 65B | 15,000
 [llama-2](https://huggingface.co/models?other=llama-2) | 7B - 70B | 900
 [mistral](https://huggingface.co/models?other=mistral) | 7B | 3,300


### PR DESCRIPTION
We now support [falcon](https://github.com/microsoft/DeepSpeed/pull/4790) and [mixtral](https://github.com/microsoft/DeepSpeed/pull/4828) models with latest DeepSpeed. Also updated the model counts.