### PR TITLE
Add restful_api_host into server args.

### DIFF
--- a/mii/backend/server.py
+++ b/mii/backend/server.py
@@ -135,6 +135,7 @@ class MIIServer:
             f"--deployment-name {mii_config.deployment_name}",
             f"--load-balancer-port {mii_config.port_number}",
             f"--restful-gateway-port {mii_config.restful_api_port}",
+            f"--restful-gateway-host {mii_config.restful_api_host}",
             f"--restful-gateway-procs {mii_config.restful_processes}"
         ]
 


### PR DESCRIPTION
I add `restful_api_host` into server args list in order to bind with another hostnames beside "localhost".