### PR TITLE
fix address already in use error on UT

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -35,6 +35,11 @@ jobs:
         run: |
           pip install .[dev]
 
+      - name: Install dependencies
+        run: |
+          grep -E "clang-format|pre-commit" requirements/requirements-dev.txt | xargs pip install
+
+
       - name: Formatting checks
         run: |
            pre-commit run --all-files

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -27,18 +27,9 @@ jobs:
           which python
           python --version
 
-      - name: Install DeepSpeed
-        run: |
-          pip install git+https://github.com/microsoft/DeepSpeed.git
-
-      - name: Install MII
-        run: |
-          pip install .[dev]
-
       - name: Install dependencies
         run: |
           grep -E "clang-format|pre-commit" requirements/requirements-dev.txt | xargs pip install
-
 
       - name: Formatting checks
         run: |

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,3 +1,4 @@
-pre-commit
+clang-format==16.0.2
+pre-commit>=2.20.0
 pytest
 pytest-forked

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import mii
 from types import SimpleNamespace
 from typing import Union
 from deepspeed.launcher.runner import DLTS_HOSTFILE
+import deepspeed.comm as dist
 
 
 @pytest.fixture(scope="function", params=[None])
@@ -143,6 +144,7 @@ def pipeline(model_config, expected_failure):
         pipe = mii.pipeline(model_config=model_config)
         yield pipe
         pipe.destroy()
+        dist.destroy_process_group()
 
 
 @pytest.fixture(scope="function")
@@ -155,7 +157,7 @@ def deployment(mii_config, expected_failure):
         client = mii.serve(mii_config=mii_config)
         yield client
         client.terminate_server()
-        time.sleep(1)
+        time.sleep(1)  # Give a second for ports to be released
 
 
 @pytest.fixture(scope="function", params=["DeepSpeed is the greatest"], ids=["query0"])


### PR DESCRIPTION
If `test_pipeline` tests run before `test_deployment` tests, we would run into an `Address already in use` error. Needed to destroy the pytorch process group when tearing down the Pipeline object.