### PR TITLE
Improve efficiency of ragged batching scheduler

### DIFF
--- a/mii/batching/data_classes.py
+++ b/mii/batching/data_classes.py
@@ -225,20 +225,20 @@ class RequestBatch:
         return [r.next_token for r in self.requests]
 
     @property
-    def done_tokens(self) -> List[torch.Tensor]:
+    def done_tokens(self) -> List[bool]:
         return [r.is_done for r in self.requests]
 
     @next_tokens.setter
-    def next_tokens(self, next_tokens: List[torch.Tensor]) -> None:
+    def next_tokens(self, next_tokens: torch.Tensor) -> None:
         assert len(next_tokens) == len(self.requests)
         for idx, r in enumerate(self.requests):
             r.next_token = next_tokens[idx]
 
     @done_tokens.setter
-    def done_tokens(self, done_tokens: List[torch.Tensor]) -> None:
+    def done_tokens(self, done_tokens: torch.Tensor) -> None:
         assert len(done_tokens) == len(self.requests)
         for idx, r in enumerate(self.requests):
-            r.is_done = done_tokens[idx]
+            r.is_done = done_tokens[idx].item()
 
     def to_msg_dicts(self) -> List[Dict[str, Any]]:
         return [r.to_msg_dict() for r in self.requests]

--- a/mii/batching/generation/logit_processors.py
+++ b/mii/batching/generation/logit_processors.py
@@ -54,10 +54,11 @@ class TopPLogitProcessor(BaseLogitProcessor):
         # above the threshold
         sorted_indices_to_remove[..., 1:] = sorted_indices_to_remove[..., :-1].clone()
         sorted_indices_to_remove[..., 0] = 0
-        for i in range(sorted_indices.size(0)):
-            indices_to_remove = sorted_indices[i][sorted_indices_to_remove[i]]
-            logits[i][indices_to_remove] = FLOAT_PAD
-        return logits
+
+        indices_to_remove = sorted_indices_to_remove.scatter(1,
+                                                             sorted_indices,
+                                                             sorted_indices_to_remove)
+        return logits.masked_fill(indices_to_remove, FLOAT_PAD)
 
     def get_key(self) -> str:
         return super().get_key() + f"_top_p={self.top_p}"

--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -194,6 +194,7 @@ class RaggedBatchBase:
                                           running_requests,
                                           self._post_processors)
         next_tokens = next_tokens.to(torch.device("cpu"), non_blocking=False)
+        done_tokens = done_tokens.to(torch.device("cpu"), non_blocking=False)
         return next_tokens, done_tokens
 
     @sync_debug


### PR DESCRIPTION
This PR includes the following optimization in the ragged batching scheduler:
- Remove inefficient loop in TopP logits processor (390302476251c9d58ea443900a0388e8d006f19f): The loop in Top P processor is inefficient when it runs on multiple requests. This PR replaces the loop with a batch API with indexing. 
- Copying `is_done` flag of requests to host memory as a batch (678673734503b14ed5a9b9dd7ec7d7e1efa6d0eb): is_done is computed on cuda but implicitly copied to host every time it is evaluated as bool. This PR copies it to host at once and stores them as Python bool values.