### PR TITLE
Improve efficiency of scheduling and token sampiling

### DIFF
--- a/mii/batching/data_classes.py
+++ b/mii/batching/data_classes.py
@@ -225,20 +225,20 @@ class RequestBatch:
         return [r.next_token for r in self.requests]
 
     @property
-    def done_tokens(self) -> List[torch.Tensor]:
+    def done_tokens(self) -> List[bool]:
         return [r.is_done for r in self.requests]
 
     @next_tokens.setter
-    def next_tokens(self, next_tokens: List[torch.Tensor]) -> None:
+    def next_tokens(self, next_tokens: torch.Tensor) -> None:
         assert len(next_tokens) == len(self.requests)
         for idx, r in enumerate(self.requests):
             r.next_token = next_tokens[idx]
 
     @done_tokens.setter
-    def done_tokens(self, done_tokens: List[torch.Tensor]) -> None:
+    def done_tokens(self, done_tokens: torch.Tensor) -> None:
         assert len(done_tokens) == len(self.requests)
         for idx, r in enumerate(self.requests):
-            r.is_done = done_tokens[idx]
+            r.is_done = done_tokens[idx].item()
 
     def to_msg_dicts(self) -> List[Dict[str, Any]]:
         return [r.to_msg_dict() for r in self.requests]

--- a/mii/batching/generation/logit_processors.py
+++ b/mii/batching/generation/logit_processors.py
@@ -54,10 +54,11 @@ class TopPLogitProcessor(BaseLogitProcessor):
         # above the threshold
         sorted_indices_to_remove[..., 1:] = sorted_indices_to_remove[..., :-1].clone()
         sorted_indices_to_remove[..., 0] = 0
-        for i in range(sorted_indices.size(0)):
-            indices_to_remove = sorted_indices[i][sorted_indices_to_remove[i]]
-            logits[i][indices_to_remove] = FLOAT_PAD
-        return logits
+
+        indices_to_remove = sorted_indices_to_remove.scatter(1,
+                                                             sorted_indices,
+                                                             sorted_indices_to_remove)
+        return logits.masked_fill(indices_to_remove, FLOAT_PAD)
 
     def get_key(self) -> str:
         return super().get_key() + f"_top_p={self.top_p}"

--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -443,7 +443,7 @@ class RaggedBatchBase:
 
     def put(self, uids: List[int], tokenized_input: List[torch.Tensor]) -> torch.Tensor:
         # Call inference engine. You can skip checking schedulability because we already checked when scheduling
-        return self.inference_engine.put(uids, tokenized_input, skip_check=True)
+        return self.inference_engine.put(uids, tokenized_input, do_checks=False)
 
     def flush(self, uids: List[int]) -> None:
         for uid in uids:

--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -442,7 +442,8 @@ class RaggedBatchBase:
                         finish_reason=finish_reason)
 
     def put(self, uids: List[int], tokenized_input: List[torch.Tensor]) -> torch.Tensor:
-        return self.inference_engine.put(uids, tokenized_input)
+        # Call inference engine. You can skip checking schedulability because we already checked when scheduling
+        return self.inference_engine.put(uids, tokenized_input, skip_check=True)
 
     def flush(self, uids: List[int]) -> None:
         for uid in uids:

--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -55,9 +55,7 @@ class RaggedBatchBase:
         self.buffer = deque()
         self.scheduled_length = 0
         self.scheduled_seq_num = 0
-        self.scheduled_req_blocks = torch.zeros(inference_engine.n_kv_cache_groups,
-                                                dtype=torch.int32,
-                                                device="cpu")
+        self.scheduled_req_blocks = 0
 
         # TODO: we will need to prune self._post_processors for long running deployments
         self._post_processors = {}
@@ -175,7 +173,7 @@ class RaggedBatchBase:
         self.scheduled_requests = RequestBatch()
         self.scheduled_length = 0
         self.scheduled_seq_num = 0
-        self.scheduled_req_blocks.zero_()
+        self.scheduled_req_blocks = 0
 
     @sync_debug
     def _process_logits(
@@ -227,12 +225,33 @@ class RaggedBatchBase:
         for output in outputs:
             self.result_queues[r.tid].put_nowait(output)
 
-    def _do_schedule_requests(self, requests: List[Request]) -> None:
-
-        free_blocks = self.inference_engine.free_blocks
+    def _schedule_token_gen(self, requests: List[Request]) -> None:
+        free_blocks = self.inference_engine.free_blocks.min().item()
         conf_manager = self.inference_engine._config.state_manager
+
+        num_schedulable = min(len(requests), conf_manager.max_ragged_sequence_count)
+        num_schedulable = min(num_schedulable, conf_manager.max_ragged_batch_size)
+
+        for r in requests[:num_schedulable]:
+            block_capacity = self.inference_engine.get_remaining_block_capacity(r.uid)
+            # We can schedule token generation if the last block has a capacity
+            if block_capacity > 0:
+                self.scheduled_length += 1
+                self.scheduled_requests.append(r)
+            else:
+                # We need a new block
+                if free_blocks > 0:
+                    free_blocks -= 1
+                    self.scheduled_length += 1
+                    self.scheduled_req_blocks += 1
+                    self.scheduled_requests.append(r)
+
+    def _schedule_prompts(self, requests: List[Request]) -> None:
+        free_blocks = self.inference_engine.free_blocks.min().item()
+        conf_manager = self.inference_engine._config.state_manager
+
         for r in requests:
-            if free_blocks.min().item() == 0:
+            if free_blocks == 0:
                 break
 
             if r.max_length <= r.seq_length:
@@ -286,7 +305,6 @@ class RaggedBatchBase:
             r = self.request_queue.get_nowait()
             self.buffer.append(r)
 
-        # Run next token generation first
         next_token_gen_reqs = []
         prompt_reqs = []
 
@@ -294,14 +312,15 @@ class RaggedBatchBase:
             if r.is_flush_request:
                 self.scheduled_requests.append(r)
             else:
-                if len(r.input_tokens) == 1:
-                    next_token_gen_reqs.append(r)
+                if r.num_generated_tokens > 0:
+                    if r.max_length > r.seq_length:
+                        next_token_gen_reqs.append(r)
                 else:
                     prompt_reqs.append(r)
 
         # We want to process next token generation first
-        self._do_schedule_requests(next_token_gen_reqs)
-        self._do_schedule_requests(prompt_reqs)
+        self._schedule_token_gen(next_token_gen_reqs)
+        self._schedule_prompts(prompt_reqs)
 
         if len(self.buffer) > 0 and len(self.scheduled_requests) == 0:
             print(

--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -226,7 +226,7 @@ class RaggedBatchBase:
             self.result_queues[r.tid].put_nowait(output)
 
     def _schedule_token_gen(self, requests: List[Request]) -> None:
-        free_blocks = self.inference_engine.free_blocks.min().item()
+        free_blocks = min(self.inference_engine.free_blocks)
         conf_manager = self.inference_engine._config.state_manager
 
         num_schedulable = min(len(requests), conf_manager.max_ragged_sequence_count)
@@ -247,7 +247,7 @@ class RaggedBatchBase:
                     self.scheduled_requests.append(r)
 
     def _schedule_prompts(self, requests: List[Request]) -> None:
-        free_blocks = self.inference_engine.free_blocks.min().item()
+        free_blocks = min(self.inference_engine.free_blocks)
         conf_manager = self.inference_engine._config.state_manager
 
         for r in requests:

--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -194,6 +194,7 @@ class RaggedBatchBase:
                                           running_requests,
                                           self._post_processors)
         next_tokens = next_tokens.to(torch.device("cpu"), non_blocking=False)
+        done_tokens = done_tokens.to(torch.device("cpu"), non_blocking=False)
         return next_tokens, done_tokens
 
     @sync_debug

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 asyncio
-deepspeed>=0.12.7
+deepspeed>=0.12.4
 deepspeed-kernels
 Flask-RESTful
 grpcio

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 asyncio
-deepspeed>=0.12.4
+deepspeed>=0.12.7
 deepspeed-kernels
 Flask-RESTful
 grpcio


### PR DESCRIPTION
(NOTE: This PR requires the new APIs introduced in https://github.com/microsoft/DeepSpeed/pull/4965)

This PR improves the efficiency scheduling for ragged batching.
- Use a new faster API to query KV cache status (94ebae10bae0191f5c3450819285f166f6875bc9)
- Improved efficiency of Top P logits processor by avoiding an inefficient loop (390302476251c9d58ea443900a0388e8d006f19f)
- Skip duplicated check of schedulability (904e5009e2445b830613a8bfb4b5a01634236ab0)
- Use python int values and lists instead of torch tensors to maintain KV cache status. Using torch tensors has a certain overhead and it becomes significant when they are frequently called in loops (bfdb5db019c44df9a642af513ded4a5ac1374be7)
