### PR TITLE
Make the order of outputs the same as the order of inputs when using `mii.pipeline`

### DIFF
--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -483,7 +483,7 @@ class MIIPipeline(RaggedBatchBase):
                     uid, response = self._get_response()
                     outputs.append(response)
                     self._queue_flush_request(uid)
-                    uids_complete_order.append(uids_running.index(uid))
+                    uids_complete_order.append(uid)
                     uids_running.remove(uid)
             # Ensure final flush requests broadcast and
             # kick ranks 1 -> n out of the while loop


### PR DESCRIPTION
When doing batch inference using the "Non-Persistent Pipeline" method, i.e. using `mii.pipeline`, the order of outputs is arbitrary, and has no correlation with the order of inputs. This becomes especially obvious when the generated outputs are of varying lengths and therefore finish at different times.

In fact, printing the output if this line of code `uids_complete_order.append(uids_running.index(uid))` would make it clear that it is incorrect, given that it outputs the same index multiple times.

I have tested this PR on a single GPU.