### PR TITLE
Fix recovery from deadlock

### DIFF
--- a/mii/batching/data_classes.py
+++ b/mii/batching/data_classes.py
@@ -88,6 +88,10 @@ class Request:
     def max_new_tokens(self) -> int:
         return self.generate_params.max_new_tokens
 
+    @max_new_tokens.setter
+    def max_new_tokens(self, max_new_tokens: int) -> None:
+        self.generate_params.max_new_tokens = max_new_tokens
+
     @property
     def stream(self) -> bool:
         return self.generate_params.stream


### PR DESCRIPTION
The batch scheduler updates `max_new_tokens` when it tries to recover from a deadlock.
This always fails because now `max_new_tokens` is a read-only property of the request class.
```python
    new_req.max_new_tokens = r.max_new_tokens - len(r.generated_tokens)
```
This PR adds the setter to update `max_new_tokens`. Another option is to create a new request object.