### PR TITLE
Readable token streaming support

### DIFF
--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -28,6 +28,19 @@ def test_streaming(deployment, query):
     assert outputs, "output is empty"
 
 
+def test_streaming_consistency(deployment, query):
+    expected_output = deployment(query, do_sample=False)
+    streaming_parts = []
+
+    def callback(response):
+        streaming_parts.append(response[0].generated_text)
+
+    deployment(query, do_sample=False, streaming_fn=callback)
+    streaming_output = "".join(streaming_parts)
+
+    assert streaming_output == expected_output[0].generated_text, "outputs w and w/o streaming are not equal"
+
+
 def test_multi_prompt(deployment, query):
     outputs = deployment([query] * 4)
     for r in outputs:

--- a/tests/test_ragged_batching.py
+++ b/tests/test_ragged_batching.py
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+import pytest
+
+from mii.batching.ragged_batching import ReadableStream
+from mii.config import ModelConfig
+from mii.modeling.tokenizers import load_tokenizer
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "tiiuae/falcon-7b",
+        "NousResearch/Llama-2-7b-hf",
+        "mistralai/Mistral-7B-v0.1",
+        "cloudyu/Mixtral_11Bx2_MoE_19B",
+        "facebook/opt-125m",
+    ],
+    ids=["falcon",
+         "llama",
+         "mistral",
+         "mixtral",
+         "opt"],
+)
+@pytest.mark.parametrize(
+    "query",
+    [
+        "It’s a region that includes Washington, Oregon, and Idaho.",
+        "# Heading\n\n<s>title</s>   redundant  spaces, #id — an anchor",
+        "例如",
+    ],
+    ids=[
+        "apostrophe",
+        "markdown",
+        "chinese",
+    ])
+def test_readable_stream(model_config, query):
+    tokenizer = load_tokenizer(ModelConfig(**model_config))
+    thread_id = 42
+
+    token_ids = tokenizer.encode(query)
+    expected = tokenizer.decode(token_ids)
+    decoded = []
+
+    stream = ReadableStream(tokenizer)
+    for token_id in token_ids:
+        decoded.append(stream.decode(thread_id, [token_id]))
+
+    assert "".join(decoded) == expected


### PR DESCRIPTION
Hey folks,

Thank you for this amazing library! :)  

I waited a bit for #311 to resolve, but eventually decided to help complete it.  

The original @jeffra's commit is cherry-picked, so the commit history stays valid!

# Description

While testing the original PR, I stumbled upon several issues:

* It trimmed redundant spaces (`the   example` becomes `the example`), because it was based on the space splitting

* It sometimes replaced more characters than needed (if the previous token was found multiple times in the current token, like `an anchor` becomes `an chor`)

* It didn't work properly when more than two tokens are required to decode the symbol

For example, with `tiiuae/falcon-7b` tokenizer, `例如` becomes `�如` (the first symbol is a Unicode `REPLACEMENT CHARACTER`)  

My approach is slightly different then used before.

Two consequent tokens are always stored in the form of a token_ids sequence. The idea is to find the difference between previous and (previous + current) token decode results:

```python
def example(...)
    ...
    # n - is the size of the previous token
    prev = tokenizer.decode(token_ids[:n])
    both = tokenizer.decode(token_ids)
    result = both.replace(prev, "", 1)
    token_ids = token_ids[n:]
    return result
```

I added unit tests for the `ReadableStream` for all supported models + one sanity test checking consistency between regular inference and streaming inference.

Should address: #306, #281, #347
