### PR TITLE
Improve recovery from KV cache starvation

### DIFF
--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -356,7 +356,7 @@ class RaggedBatchBase:
         for r in self.buffer:
             if r.seq_length > 0:
                 last_r = r
-        assert last_r is not None
+        assert last_r is not None, "Function to clear the KV cache is invoked, but no request consumes KV cache"
 
         ## Schedule flushing r
         self.scheduled_requests.append(


### PR DESCRIPTION
This PRs improves efficiency when we are running out of KV cache.

Currently, we free the KV cache for all ongoing requests when we fail to schedule any request. This PR changes this strategy by only freeing the cache allocated to the last request. This approach reduces the recomputation cost and prevents the generation from getting stuck.