### PR TITLE
fix: Fixed the issue where the mii.pipeline.pipe(stop) was ineffective

### DIFF
--- a/mii/batching/generation/stop_criterion.py
+++ b/mii/batching/generation/stop_criterion.py
@@ -30,7 +30,7 @@ class TokenStopCriterion(BaseGenerationStopCriterion):
     def __init__(self, token: Union[str, int], tokenizer) -> None:
         super().__init__(tokenizer=tokenizer)
         if isinstance(token, str):
-            token_id = self.tokenizer.encode(token)[0]
+            token_id = self.tokenizer.convert_tokens_to_ids(token)
         else:
             token_id = token
         self.stop_token_id = token_id

--- a/mii/batching/postprocess.py
+++ b/mii/batching/postprocess.py
@@ -76,4 +76,6 @@ def run_batch_stop_criterion(next_tokens: torch.Tensor,
                                                  Any]) -> torch.Tensor:
     stop_fns = {k: v for k, v in processor_map.items() if "Stop" in k}
     done_tokens = run_batch_processing(next_tokens, requests, stop_fns)
+    done_tokens = torch.any(done_tokens.view((len(requests), -1)), dim=1)
+
     return done_tokens

--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -437,17 +437,19 @@ class RaggedBatchBase:
 
         stop = generate_params.stop
         if stop != []:
-            stop_name = "_".join([STOP_NAME] + stop)
-            if stop_name not in self._post_processors:
-                self._post_processors[stop_name] = TokenStopCriterion(
-                    token=stop,
-                    tokenizer=self.tokenizer)
+            for each_stop in stop:
+                stop_name = STOP_NAME + '_' + each_stop
+                if stop_name not in self._post_processors:
+                    self._post_processors[stop_name] = TokenStopCriterion(
+                        token=each_stop,
+                        tokenizer=self.tokenizer)
+                post_processing.append(stop_name)
         else:
             stop_name = STOP_NAME
             if STOP_NAME not in self._post_processors:
                 self._post_processors[stop_name] = EosGenerationStopCriterion(
                     tokenizer=self.tokenizer)
-        post_processing.append(stop_name)
+            post_processing.append(stop_name)
 
         return Request(
             tid=tid,

--- a/mii/modeling/tokenizers.py
+++ b/mii/modeling/tokenizers.py
@@ -60,6 +60,9 @@ class HFTokenizer(MIITokenizerWrapper):
     def encode(self, input: str) -> torch.Tensor:
         return self.tokenizer.encode(input, return_tensors="pt").flatten()
 
+    def convert_tokens_to_ids(self, input: str) -> int:
+        return self.tokenizer.convert_tokens_to_ids(input)
+
     def decode(self, tokens: torch.Tensor) -> str:
         return self.tokenizer.decode(tokens)
 


### PR DESCRIPTION
1. Replace Tokenizer.encode with Tokenizer.convert_tokens_to_ids
2. Support multi stop tokens and batch inference

Easy reproduce by
responses = pipe(args.prompt,
    do_sample=False,
    max_new_tokens=args.max_new_tokens,
    return_full_text=True,
    stop=["<|im_end|>", "<h1>"])