### PR TITLE
Update GH workflow and workflow runner requirements.

### DIFF
--- a/.github/workflows/nv-v100-legacy.yml
+++ b/.github/workflows/nv-v100-legacy.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, cu116, v100]
+    runs-on: [self-hosted, nvidia, cu117, v100]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nv-v100-legacy.yml
+++ b/.github/workflows/nv-v100-legacy.yml
@@ -9,7 +9,7 @@ on:
       - 'mii/__init__.py'
       - 'mii/legacy/**'
       - 'tests/legacy/**'
-      - '.github/workflows/nv-torch-latest-v100.yml'
+      - '.github/workflows/nv-v100-legacy.yml'
       - 'requirements/**'
       - 'setup.py'
 


### PR DESCRIPTION
- The path to trigger the nv-v100-legacy workflow was incorrect and is now updated.
- The requirements for the runner are updated to use cu117.

[Before](https://github.com/microsoft/DeepSpeed-MII/actions/runs/8501872742/job/23285292094#step:8:138):
================== 27 passed, 5 warnings in 567.11s (0:09:27) ==================


[After](https://github.com/microsoft/DeepSpeed-MII/actions/runs/8545226316/job/23413014086?pr=456):
================== 27 passed, 5 warnings in 562.81s (0:09:22) ==================