### PR TITLE
fix max_ragged_sequence_count check in _schedule_prompts

### DIFF
--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -264,7 +264,8 @@ class RaggedBatchBase:
                 continue
 
             # Make sure that the engine has enough capacity to process the batch
-            if len(self.scheduled_requests) > conf_manager.max_ragged_sequence_count:
+            if len(self.scheduled_requests.requests_to_run
+                   ) >= conf_manager.max_ragged_sequence_count:
                 break
 
             max_batch_size = conf_manager.max_ragged_batch_size - self.scheduled_length


### PR DESCRIPTION
- scheduling prompt should break when length of request **equals** `max_ragged_sequence_count`
- considering there are flush requests, should use `scheduled_requests.requests_to_run` rather than `scheduled_requests`

@loadams @mrwyattii can you help review this fix? thanks~