### PR TITLE
Fix deprecation warning on escaped characters

### DIFF
--- a/mii/backend/client.py
+++ b/mii/backend/client.py
@@ -77,7 +77,7 @@ class MIIClient:
 
         :param prompts: The string or list of strings used as prompts for generation.
         :param streaming_fn: Streaming support is currently a WIP.
-        :param \**generate_kwargs: Generation keywords. A full list can be found here.
+        :param \\*\\*generate_kwargs: Generation keywords. A full list can be found here.
 
         :return: A list of :class:`Response` objects containing the generated
             text for all prompts.

--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -547,7 +547,7 @@ class MIIPipeline(RaggedBatchBase):
         Generates text for the given prompts
 
         :param prompts: The string or list of strings used as prompts for generation.
-        :param \**generate_kwargs: Generation keywords. A full list can be found
+        :param \\*\\*generate_kwargs: Generation keywords. A full list can be found
             in :class:`GenerateParamsConfig <mii.config.GenerateParamsConfig>`.
 
         :return: A list of :class:`Response` objects containing the generated


### PR DESCRIPTION
Resolves warnings in nv-a6000-fastgen listed [here](https://github.com/microsoft/DeepSpeed-MII/actions/runs/9099414778/job/25014622676#step:9:69)

```
../mii/backend/client.py:75
  /__w/DeepSpeed-MII/DeepSpeed-MII/mii/backend/client.py:75: DeprecationWarning: invalid escape sequence \*
    """

../mii/batching/ragged_batching.py:546
  /__w/DeepSpeed-MII/DeepSpeed-MII/mii/batching/ragged_batching.py:546: DeprecationWarning: invalid escape sequence \*
    """
```

rtd-staging branch updated [here](https://github.com/microsoft/DeepSpeed-MII/tree/rtd-staging)
rtd-staging webpage located [here](https://deepspeed-mii.readthedocs.io/en/rtd-staging/deployment.html#mii.backend.client.MIIClient.generate)