### PR TITLE
Fix scheduling for non-persistent pipeline

### DIFF
--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -37,6 +37,8 @@ from mii.logging import logger
 from mii.modeling.tokenizers import MIITokenizerWrapper
 
 
+import deepspeed.comm as dist
+
 class RaggedBatchBase:
     def __init__(self, inference_engine, tokenizer, model_config):
         self.inference_engine = inference_engine
@@ -605,6 +607,7 @@ class MIIPipeline(RaggedBatchBase):
             # Ensure final flush requests broadcast and
             # kick ranks 1 -> n out of the while loop
             self._bcast_requests(force=True)
+            self.scheduled_requests = RequestBatch()
         else:
             # Ranks 1 -> n just run generate() until there are no more requests
             exit = False

--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -607,6 +607,7 @@ class MIIPipeline(RaggedBatchBase):
             # Ensure final flush requests broadcast and
             # kick ranks 1 -> n out of the while loop
             self._bcast_requests(force=True)
+            self.flush(self.scheduled_requests.requests_to_flush.uids)
             self.scheduled_requests = RequestBatch()
         else:
             # Ranks 1 -> n just run generate() until there are no more requests

--- a/mii/batching/ragged_batching.py
+++ b/mii/batching/ragged_batching.py
@@ -37,8 +37,6 @@ from mii.logging import logger
 from mii.modeling.tokenizers import MIITokenizerWrapper
 
 
-import deepspeed.comm as dist
-
 class RaggedBatchBase:
     def __init__(self, inference_engine, tokenizer, model_config):
         self.inference_engine = inference_engine

--- a/mii/legacy/logging.py
+++ b/mii/legacy/logging.py
@@ -42,4 +42,4 @@ class LoggerFactory:
         return logger_
 
 
-logger = LoggerFactory.create_logger(name="MII", level=logging.INFO)
+logger = LoggerFactory.create_logger(name="MII_legacy", level=logging.INFO)


### PR DESCRIPTION
The batch scheduler for FastGen is designed to run only on rank 0, but currently it runs on all ranks when TP is enabled. This causes various unexpected behaviors.
This PR fixes this issue by properly settings a device ID and flushing remaining requests.