### PR TITLE
Update docker container version

### DIFF
--- a/.github/workflows/nv-a6000-fastgen.yml
+++ b/.github/workflows/nv-a6000-fastgen.yml
@@ -18,7 +18,7 @@ jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, a6000]
     container:
-      image: nvcr.io/nvidia/pytorch:23.03-py3
+      image: nvcr.io/nvidia/pytorch:24.03-py3
       ports:
         - 80
       options: --gpus all --shm-size "8G"


### PR DESCRIPTION
MII uses transformers which dropped support for python 3.8 in its latest release.  The CI tests used a docker container that was using python 3.8 and this updates to one using python 3.10.

DeepSpeed equivalent PR: https://github.com/microsoft/DeepSpeed/pull/6681