### PR TITLE
Update labels to acquire new runners

### DIFF
--- a/.github/workflows/nv-v100-legacy.yml
+++ b/.github/workflows/nv-v100-legacy.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install pytorch
         run: |
-          pip3 install -U --cache-dir /blob/torch_cache/ torch --index-url https://download.pytorch.org/whl/cu118
+          pip3 install -U --cache-dir /blob/torch_cache/ torch --index-url https://download.pytorch.org/whl/cu121
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-v100-legacy.yml
+++ b/.github/workflows/nv-v100-legacy.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, cu117, v100]
+    runs-on: [self-hosted, nvidia, cu121, v100]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The V100 runners now use cuda 12.1, this needed to be updated in the yml in order to run.